### PR TITLE
chore: set up release-please workflow to automate releases using Conventional Commits

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,26 @@
+on:
+  push:
+    branches:
+      - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+name: release-please
+jobs:
+  release-please:
+    runs-on: ARM64
+    steps:
+      # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+      # For why we need to generate a token and not use the default
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.CZI_RELEASE_PLEASE_APP_ID }}
+          private_key: ${{ secrets.CZI_RELEASE_PLEASE_PK }}
+
+      - name: release please
+        uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
# Descriptiob
The release-please GitHub Action automatically scans our commit history to determine the next release version, updates our changelog, and prepares a release pull request. This removes manual steps and helps maintain a consistent release process.

The action (googleapis/release-please-action@v4) uses the generated token to authenticate and then analyzes the commits merged into the main branch. It determines whether a new release is needed by examining the commit messages.

## Changelog
If new features, bug fixes, or breaking changes are found, the action automatically bumps the version (major, minor, or patch) and updates the changelog accordingly. It also tags the release, preparing everything for a seamless deployment once merged. 

## Integration with Conventional Commits
The workflow is tightly coupled with the Conventional Commits specification. This means that each commit must clearly indicate the nature of the change (e.g., feat:, fix:, or BREAKING CHANGE:).
- Commits that start with `feat:` trigger a minor version bump.
- Commits that start with `fix:` trigger a patch version bump.
- Commits indicating a breaking change (e.g., through `BREAKING CHANGE:` or an exclamation mark like `feat!:`) trigger a major version bump.

## Impact 
- Consistency: Automated detection of version changes and changelog updates reduce human error.
- Efficiency: Streamlines the release process by automatically creating a PR for release review.
- Transparency: Clear versioning and release notes improve communication within the team and with external users.