### PR TITLE
chore: fix model weights dir string

### DIFF
--- a/src/czibench/models/implementations/base_model_implementation.py
+++ b/src/czibench/models/implementations/base_model_implementation.py
@@ -69,8 +69,7 @@ class BaseModelImplementation(BaseModelValidator, ABC):
             dataset: Dataset being processed
         """
         self.model_weights_dir = (
-            f"{MODEL_WEIGHTS_PATH_DOCKER}/"
-            f"{self.get_model_weights_subdir(dataset)}"
+            f"{MODEL_WEIGHTS_PATH_DOCKER}/{self.get_model_weights_subdir(dataset)}"
         )
 
         if not os.path.exists(self.model_weights_dir) or not any(


### PR DESCRIPTION
Multi-line strings include newlines and spaces, which breaks path formatting.