### PR TITLE
chore: update perturb datasets

### DIFF
--- a/conf/datasets.yaml
+++ b/conf/datasets.yaml
@@ -2,23 +2,40 @@ defaults:
   - _self_
 
 datasets:
-  adamson:
+  adamson_perturb:
     _target_: czibench.datasets.single_cell.PerturbationSingleCellDataset
     organism: ${organism:HUMAN}
     condition_key: condition
-    path: s3://generate-cross-species/datasets/perturbation/single_cell/adamson.h5ad
+    split_key: split
+    path: s3://generate-cross-species/datasets/perturb/single_cell/adamson.h5ad
 
-  norman:
+  norman_perturb:
     _target_: czibench.datasets.single_cell.PerturbationSingleCellDataset
     organism: ${organism:HUMAN}
     condition_key: condition
-    path: s3://generate-cross-species/datasets/perturbation/single_cell/norman.h5ad
+    split_key: split
+    path: s3://generate-cross-species/datasets/perturb/single_cell/norman.h5ad
 
-  dixit:
+  dixit_perturb:
     _target_: czibench.datasets.single_cell.PerturbationSingleCellDataset
     organism: ${organism:HUMAN}
     condition_key: condition
-    path: s3://generate-cross-species/datasets/perturbation/single_cell/dixit.h5ad
+    split_key: split
+    path: s3://generate-cross-species/datasets/perturb/single_cell/dixit.h5ad
+
+  replogle_k562_perturb:
+    _target_: czibench.datasets.single_cell.PerturbationSingleCellDataset
+    organism: ${organism:HUMAN}
+    condition_key: condition
+    split_key: split
+    path: s3://generate-cross-species/datasets/perturb/single_cell/replogle_k562_essential_perturbation.h5ad
+
+  replogle_rpe1_perturb:
+    _target_: czibench.datasets.single_cell.PerturbationSingleCellDataset
+    organism: ${organism:HUMAN}
+    condition_key: condition
+    split_key: split
+    path: s3://generate-cross-species/datasets/perturb/single_cell/replogle_rpe1_essential_perturbation.h5ad
 
   example:
     _target_: czibench.datasets.single_cell.SingleCellDataset


### PR DESCRIPTION
Update perturbation datasets with the appropriate splits.

Code used:


```python
from gears import PertData, GEARS
import numpy as np
import pandas as pd

def write_perturb_data(
    dataset_name, data_dir, batch_size, val_batch_size, split="simulation"
):
    pert_data = PertData("data/")    
    pert_data.load(data_name=dataset_name)
    pert_data.prepare_split(split='simulation', seed=1)
    pert_data.get_dataloader(batch_size=64, test_batch_size=64)
    
    splits = np.zeros(pert_data.adata.shape[0],dtype='object')
    for split in ['test','train','val']:
        splits[pert_data.adata.obs['condition'].isin(pert_data.set2conditions[split])] = split
    pert_data.adata.obs['split'] = pd.Categorical(splits)   

    pert_data.adata.var['gene_symbol'] = pert_data.adata.var['gene_name']
    del pert_data.adata.var['gene_name']

    pert_data.adata.write_h5ad(f"perturbation_data/{dataset_name}_perturbation.h5ad")    
    
# List of all dataset names
dataset_names = ['norman', 'adamson', 'replogle_k562_essential', 'replogle_rpe1_essential', 'dixit']

# Iterate through each dataset
for dataset_name in dataset_names:
    print(f"Processing dataset: {dataset_name}")
    write_perturb_data(dataset_name, 'data', 64, 64)
```