### PR TITLE
fix: specify release-type as python for release-please.yaml

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,3 +1,5 @@
+name: release-please
+
 on:
   push:
     branches:
@@ -5,10 +7,13 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-name: release-please
+
 jobs:
   release-please:
     runs-on: ARM64
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
       # For why we need to generate a token and not use the default
@@ -24,3 +29,4 @@ jobs:
         id: release
         with:
           token: ${{ steps.generate_token.outputs.token }}
+          release-type: python


### PR DESCRIPTION
# Description
The release-please GHA failed because I forgot to specify a release-type for the action. I also added the permissions scope to limit the permissions available to the action