### PR TITLE
fix: add new trigger

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ARM64
+    runs-on: ubuntu-latest
     # TODO: Once the repo is public, uncomment the following and remove the test token
     # environment: pypi
     # permissions:


### PR DESCRIPTION
adds `workflow_dispatch` to publish-pypy.yml
