### PR TITLE
fix: docker builds to use pyproject.toml

### DIFF
--- a/docker/geneformer/Dockerfile
+++ b/docker/geneformer/Dockerfile
@@ -17,8 +17,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Install the czbenchmarks package
 COPY src /app/package/src
-COPY setup.py /app/package/setup.py
-COPY requirements.txt /app/package/requirements.txt
+COPY pyproject.toml /app/package/pyproject.toml
+COPY README.md /app/package/README.md
 RUN pip install -e /app/package
 
 COPY docker/geneformer/model.py .

--- a/docker/scgenept/Dockerfile
+++ b/docker/scgenept/Dockerfile
@@ -12,8 +12,8 @@ RUN git clone https://github.com/czi-ai/scGenePT.git && \
 
 # Install the czbenchmarks package
 COPY src /app/package/src
-COPY setup.py /app/package/setup.py
-COPY requirements.txt /app/package/requirements.txt
+COPY pyproject.toml /app/package/pyproject.toml
+COPY README.md /app/package/README.md
 RUN pip install -e /app/package
 
 COPY docker/scgenept/model.py .

--- a/docker/scgpt/Dockerfile
+++ b/docker/scgpt/Dockerfile
@@ -10,8 +10,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Install the czbenchmarks package
 COPY src /app/package/src
-COPY setup.py /app/package/setup.py
-COPY requirements.txt /app/package/requirements.txt
+COPY pyproject.toml /app/package/pyproject.toml
+COPY README.md /app/package/README.md
 RUN pip install -e /app/package
 
 COPY docker/scgpt/model.py .

--- a/docker/scvi/Dockerfile
+++ b/docker/scvi/Dockerfile
@@ -9,8 +9,8 @@ COPY docker/scvi/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY src /app/package/src
-COPY setup.py /app/package/setup.py
-COPY requirements.txt /app/package/requirements.txt
+COPY pyproject.toml /app/package/pyproject.toml
+COPY README.md /app/package/README.md
 
 RUN pip install -e /app/package
 

--- a/docker/uce/Dockerfile
+++ b/docker/uce/Dockerfile
@@ -30,8 +30,8 @@ RUN git clone https://github.com/giovp/UCE && \
 
 # Install the czbenchmarks package
 COPY src /app/package/src
-COPY setup.py /app/package/setup.py
-COPY requirements.txt /app/package/requirements.txt
+COPY pyproject.toml /app/package/pyproject.toml
+COPY README.md /app/package/README.md
 RUN /opt/conda/envs/uce/bin/pip install -e /app/package
 
 # Create model_files directory and empty CSV file for species protein embeddings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "A framework for benchmarking single-cell machine learning models"
 authors = [{ name = "Chan Zuckerberg Initiative", email = "pypi@chanzuckerberg.com" }]
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.11"
+requires-python = ">=3.10.12"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
This is a small PR that updates dockerfiles to use pyproject.toml since requirements and setup.py were removed. Installing from pyproject.toml requires that a README file is present, so that is also copied. 

Finally, scvi has a python version that is just below the minimum version in pyproject.toml (3.11 vs 3.10.12). I suspect that python version was previously being ignored, since the base container has not changed for scvi. I have reduced the version in pyproject.toml since there isn't a way to manually override this from the command line with an environment variable like in poetry.

If this is an unacceptable change, happy to discuss alternatives. 