### PR TITLE
fix: unpin anndata to hopefully resolve dependency resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "boto3>=1.28.0",
 
     # Data handling
-    "anndata>=0.9.0",
+    "anndata",
     "h5py>=3.8.0",
 
     "dill>=0.3.6",


### PR DESCRIPTION
Tries to resolve error thrown when running `pip install -i https://test.pypi.org/simple/ cz-benchmarks`

```
Looking in indexes: https://test.pypi.org/simple/
Collecting cz-benchmarks
  Downloading https://test-files.pythonhosted.org/packages/8c/44/9e182a75cee7725dc293cbebd887646c46646d50f9f76bddde2b13f5e6ae/cz_benchmarks-0.1.2-py3-none-any.whl.metadata (8.5 kB)
INFO: pip is looking at multiple versions of cz-benchmarks to determine which version is compatible with other requirements. This could take a while.
  Downloading https://test-files.pythonhosted.org/packages/04/04/12224b47cee5bd94343adfcd86dfd45e6c19b1ac5b2e5c3f5fa6028cb15e/cz_benchmarks-0.1.1-py3-none-any.whl.metadata (8.5 kB)
ERROR: Cannot install cz-benchmarks==0.1.1 and cz-benchmarks==0.1.2 because these package versions have conflicting dependencies.

The conflict is caused by:
    cz-benchmarks 0.1.2 depends on anndata>=0.9.0
    cz-benchmarks 0.1.1 depends on anndata>=0.9.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```