### PR TITLE
fix: pin Geneformer version and update huggingface version

### DIFF
--- a/docker/geneformer/Dockerfile
+++ b/docker/geneformer/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
 # Install Geneformer and its dependencies
 RUN git clone https://huggingface.co/ctheodoris/Geneformer && \
     cd Geneformer && \
+    git checkout 69e6887 && \
     pip install .
 
 COPY docker/geneformer/requirements.txt .

--- a/docker/geneformer/requirements.txt
+++ b/docker/geneformer/requirements.txt
@@ -1,6 +1,6 @@
 anndata==0.10.9
 boto3==1.35.29
-huggingface-hub==0.25.1
+huggingface-hub>=0.26.0,<1.0
 omegaconf==2.3.0
 hydra-core==1.3.2
 owlready2==0.46


### PR DESCRIPTION
[latest version of Geneformer fails](https://huggingface.co/ctheodoris/Geneformer/commit/a13a2cfc39aeaf4a2d223502930a6d041277d6f0) to be compatible with current `cz-benchmark` codebase, pinning to the latest known version to be compatible 