### PR TITLE
chore: don't pin dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ dependencies = [
 
     "hydra-core>=1.3.2",
     "hnswlib>=0.8.0; platform_system == 'Linux'",  # Install via conda on macOS
-    "scib-metrics==0.5.1",
-    "scikit-misc==0.5.1",
+    "scib-metrics>=0.5.1",
+    "scikit-misc>=0.5.1",
     "pydantic>=2.0.0",
 ]
 


### PR DESCRIPTION
Libraries should pretty much never pin exact versions of their dependencies because it can make the library impossible to install. E.g. you can't install two libraries at the same time that both pin a different versions of the same child dependency. So you should always be as generous as possible when restricting allowed dependency versions.

There's more work to be done here, but these two lines are the most problematic.