### PR TITLE
fix: update cache service in docker-build.yml

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -61,6 +61,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up Docker layer cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ matrix.image.custom_tag }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ matrix.image.custom_tag }}-
+
       - name: Login to Amazon ECR Public
         uses: aws-actions/amazon-ecr-login@v2
         with:
@@ -76,5 +84,5 @@ jobs:
           tags: |
             ${{ env.PUBLIC_ECR_REPO }}:${{ matrix.image.custom_tag }}
             ${{ env.PUBLIC_ECR_REPO }}:${{ matrix.image.custom_tag }}${{ github.event_name == 'release' && format('-{0}', github.event.release.tag_name) || '' }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max


### PR DESCRIPTION
# Description
The docker-build action to build/push the docker images to the public ECR failed due to the action using a legacy caching mechanism:
```
#20 ERROR: This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset
```
This updated the action to use a new caching mechanism (using `actions/cache@v4`) and updating `cache-from` and `cache-to` to use that cache path

# Tests
Manually triggered here: https://github.com/chanzuckerberg/cz-benchmarks/actions/runs/14204633351