### PR TITLE
feat: allow specifying random seed via CLI (VC-2358)

### DIFF
--- a/docs/source/developer_guides/tasks.md
+++ b/docs/source/developer_guides/tasks.md
@@ -78,6 +78,7 @@ To define a new evaluation task:
 7. **Optional Features**:  
     - Set `requires_multiple_datasets = True` if your task operates on a list of datasets
     - Call `self.set_baseline(dataset)` in your task to enable PCA baseline comparisons
+    - if your task is stochastic, use `self.random_seed` to seed sources of randomness for reproducibilty
 
 
 8. **Return Metrics**:  

--- a/docs/source/how_to_guides/add_new_task.md
+++ b/docs/source/how_to_guides/add_new_task.md
@@ -18,7 +18,8 @@ This guide explains how to create and integrate your own evaluation task into cz
     from czbenchmarks.models.types import ModelType
 
     class MyTask(BaseTask):
-        def __init__(self, my_param: int = 10):
+        def __init__(self, my_param: int = 10, *, random_seed: int = 123):
+            super().__init__(random_seed=random_seed)
             self.my_param = my_param
 
         @property
@@ -48,6 +49,7 @@ This guide explains how to create and integrate your own evaluation task into cz
 
 - Consult `czbenchmarks/tasks/base.py` for interface details and best practices.
 - Use `display_name` to provide a human-readable name for use when displaying your task
+- The `random_seed` should be used for all sources of randomness so results are reproducible
 - Use the `required_inputs` and `required_outputs` properties to specify the data types your task needs.
     - `required_inputs`: Data your task consumes (e.g., `DataType.METADATA`).
     - `required_outputs`: Data your task produces or depends on (e.g., `DataType.EMBEDDING`).

--- a/src/czbenchmarks/cli/types.py
+++ b/src/czbenchmarks/cli/types.py
@@ -1,0 +1,86 @@
+import argparse
+import operator
+from typing import Any, Generic, TypeVar
+
+from pydantic import BaseModel, computed_field
+
+from czbenchmarks.datasets import utils as dataset_utils
+from czbenchmarks.metrics.types import AggregatedMetricResult, MetricResult
+from czbenchmarks.models.types import ModelType
+from czbenchmarks.models import utils as model_utils
+from czbenchmarks.tasks.base import BaseTask
+
+
+TaskType = TypeVar("TaskType", bound=BaseTask)
+ModelArgsDict = dict[str, str | int]  # Arguments passed to model inference
+RuntimeMetricsDict = dict[
+    str, str | int | float
+]  # runtime metrics like elapsed time or CPU count, not implemented yet
+
+
+class ModelArgs(BaseModel):
+    name: str  # Upper-case model name e.g. SCVI
+    args: dict[str, list[str | int]]  # Args forwarded to the model container
+
+
+class TaskArgs(BaseModel, Generic[TaskType]):
+    model_config = {"arbitrary_types_allowed": True}  # Required to support TaskType
+    name: str  # Lower-case task name e.g. embedding
+    task: TaskType
+    set_baseline: bool
+    baseline_args: dict[str, Any]
+
+
+class DatasetDetail(BaseModel):
+    name: str
+    organism: str
+
+    @computed_field
+    @property
+    def name_display(self) -> str:
+        return dataset_utils.dataset_to_display_name(self.name)
+
+
+class TaskResult(BaseModel):
+    task_name: str
+    task_name_display: str
+    model_type: ModelType
+    datasets: list[DatasetDetail]
+    model_args: ModelArgsDict
+    metrics: list[MetricResult | AggregatedMetricResult]
+    runtime_metrics: RuntimeMetricsDict = {}  # not implementing any of these for now
+
+    @computed_field
+    @property
+    def model_name_display(self) -> str:
+        return model_utils.model_to_display_name(self.model_type, self.model_args)
+
+    @property
+    def aggregation_key(self) -> str:
+        """return a key based on the task, model, and datasets in order to aggregate the same results together"""
+        datasets = ",".join(
+            (ds.name for ds in sorted(self.datasets, key=operator.attrgetter("name")))
+        )
+        model_args = "_".join(
+            (f"{key}-{value!s}" for key, value in sorted(self.model_args.items()))
+        )
+        return f"{self.task_name}|{self.model_type}({model_args})|{datasets}"
+
+
+class CacheOptions(BaseModel):
+    download_embeddings: bool
+    upload_embeddings: bool
+    upload_results: bool
+    remote_cache_url: str
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> "CacheOptions":
+        remote_cache_url = args.remote_cache_url or ""
+        return cls(
+            remote_cache_url=remote_cache_url,
+            download_embeddings=bool(remote_cache_url)
+            and args.remote_cache_download_embeddings,
+            upload_embeddings=bool(remote_cache_url)
+            and args.remote_cache_upload_embeddings,
+            upload_results=bool(remote_cache_url) and args.remote_cache_upload_results,
+        )

--- a/src/czbenchmarks/cli/utils.py
+++ b/src/czbenchmarks/cli/utils.py
@@ -1,10 +1,17 @@
+import collections
 import functools
 import importlib.metadata
+import itertools
 import logging
 from pathlib import Path
 import subprocess
+import typing
 
 import tomli
+
+from czbenchmarks.cli.types import TaskResult
+import czbenchmarks.metrics.utils as metric_utils
+
 
 log = logging.getLogger(__name__)
 
@@ -97,3 +104,38 @@ def get_version() -> str:
 
     git_commit = _get_git_commit(version)
     return "v" + version + git_commit
+
+
+def aggregate_task_results(results: typing.Iterable[TaskResult]) -> list[TaskResult]:
+    """Aggregate the task results by task_name, model (with args), and set(datasets).
+    Each new result will have a new set of metrics, created by aggregating together
+    metrics of the same type.
+    """
+    grouped_results = collections.defaultdict(list)
+    for result in results:
+        grouped_results[result.aggregation_key].append(result)
+
+    aggregated = []
+    for results_to_agg in grouped_results.values():
+        aggregated_metrics = metric_utils.aggregate_results(
+            list(
+                itertools.chain.from_iterable(tr.metrics for tr in results_to_agg)
+            )  # cast to list is unnecessary but helps testing
+        )
+        if any(tr.runtime_metrics for tr in results_to_agg):
+            raise ValueError(
+                "Aggregating runtime_metrics for TaskResults is not supported"
+            )
+
+        first_result = results_to_agg[0]  # everything but the metrics should be common
+        aggregated_result = TaskResult(
+            task_name=first_result.task_name,
+            task_name_display=first_result.task_name_display,
+            model_type=first_result.model_type,
+            model_args=first_result.model_args,
+            datasets=first_result.datasets,
+            metrics=aggregated_metrics,
+            runtime_metrics={},
+        )
+        aggregated.append(aggregated_result)
+    return aggregated

--- a/src/czbenchmarks/metrics/types.py
+++ b/src/czbenchmarks/metrics/types.py
@@ -162,3 +162,23 @@ class MetricResult(BaseModel):
     metric_type: MetricType
     value: float
     params: Optional[Dict[str, Any]] = Field(default_factory=dict)
+
+    @property
+    def aggregation_key(self) -> str:
+        """return a key based on the metric type and params in order to aggregate the same metrics together"""
+        if self.params is None:
+            params = ""
+        else:
+            params = "_".join(
+                (f"{key}-{value}" for key, value in sorted(self.params.items()))
+            )
+        return f"{self.metric_type}({params})"
+
+
+class AggregatedMetricResult(BaseModel):
+    metric_type: MetricType
+    params: Dict[str, Any] | None = Field(default_factory=dict)
+    n_values: int
+    value: float
+    value_std_dev: float | None
+    values_raw: list[float]

--- a/src/czbenchmarks/tasks/base.py
+++ b/src/czbenchmarks/tasks/base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Set, Union
 
+from .constants import RANDOM_SEED
 from ..datasets import BaseDataset, DataType
 from ..models.types import ModelType
 from ..metrics.types import MetricResult
@@ -17,7 +18,17 @@ class BaseTask(ABC):
 
     Tasks should store any intermediate results as instance variables
     to be used in metric computation.
+
+    Args:
+        random_seed (int): Random seed for reproducibility
     """
+
+    def __init__(
+        self,
+        *,
+        random_seed: int = RANDOM_SEED,
+    ):
+        self.random_seed = random_seed
 
     @property
     @abstractmethod

--- a/src/czbenchmarks/tasks/clustering.py
+++ b/src/czbenchmarks/tasks/clustering.py
@@ -26,13 +26,14 @@ class ClusteringTask(BaseTask):
     def __init__(
         self,
         label_key: str,
-        random_seed: int = RANDOM_SEED,
         n_iterations: int = N_ITERATIONS,
         flavor: str = FLAVOR,
         key_added: str = KEY_ADDED,
+        *,
+        random_seed: int = RANDOM_SEED,
     ):
+        super().__init__(random_seed=random_seed)
         self.label_key = label_key
-        self.random_seed = random_seed
         self.n_iterations = n_iterations
         self.flavor = flavor
         self.key_added = key_added
@@ -97,6 +98,7 @@ class ClusteringTask(BaseTask):
                     labels_true=self.input_labels,
                     labels_pred=self.predicted_labels,
                 ),
+                params={},
             )
             for metric_type in [
                 MetricType.ADJUSTED_RAND_INDEX,

--- a/src/czbenchmarks/tasks/embedding.py
+++ b/src/czbenchmarks/tasks/embedding.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Set, List
 
+from .constants import RANDOM_SEED
 from ..datasets import BaseDataset, DataType
 from ..models.types import ModelType
 from ..metrics import metrics_registry
@@ -18,9 +19,11 @@ class EmbeddingTask(BaseTask):
 
     Args:
         label_key (str): Key to access ground truth labels in metadata
+        random_seed (int): Random seed for reproducibility
     """
 
-    def __init__(self, label_key: str):
+    def __init__(self, label_key: str, *, random_seed: int = RANDOM_SEED):
+        super().__init__(random_seed=random_seed)
         self.label_key = label_key
 
     @property

--- a/src/czbenchmarks/tasks/integration.py
+++ b/src/czbenchmarks/tasks/integration.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Set, List
 
+from .constants import RANDOM_SEED
 from ..datasets import BaseDataset, DataType
 from ..models.types import ModelType
 from ..metrics import metrics_registry
@@ -19,9 +20,13 @@ class BatchIntegrationTask(BaseTask):
     Args:
         label_key: Key to access ground truth cell type labels in metadata
         batch_key: Key to access batch labels in metadata
+        random_seed (int): Random seed for reproducibility
     """
 
-    def __init__(self, label_key: str, batch_key: str):
+    def __init__(
+        self, label_key: str, batch_key: str, *, random_seed: int = RANDOM_SEED
+    ):
+        super().__init__(random_seed=random_seed)
         self.label_key = label_key
         self.batch_key = batch_key
 

--- a/src/czbenchmarks/tasks/label_prediction.py
+++ b/src/czbenchmarks/tasks/label_prediction.py
@@ -38,20 +38,21 @@ class MetadataLabelPredictionTask(BaseTask):
     Args:
         label_key: Key to access ground truth labels in metadata
         n_folds: Number of cross-validation folds
-        random_seed: Random seed for reproducibility
         min_class_size: Minimum samples required per class
+        random_seed (int): Random seed for reproducibility
     """
 
     def __init__(
         self,
         label_key: str,
         n_folds: int = N_FOLDS,
-        random_seed: int = RANDOM_SEED,
         min_class_size: int = MIN_CLASS_SIZE,
+        *,
+        random_seed: int = RANDOM_SEED,
     ):
+        super().__init__(random_seed=random_seed)
         self.label_key = label_key
         self.n_folds = n_folds
-        self.random_seed = random_seed
         self.min_class_size = min_class_size
         logger.info(
             "Initialized MetadataLabelPredictionTask with: "
@@ -188,6 +189,7 @@ class MetadataLabelPredictionTask(BaseTask):
         results_df = pd.DataFrame(self.results)
         metrics_list = []
 
+        common_params = {}
         # Calculate overall metrics across all classifiers
         metrics_list.extend(
             [
@@ -196,36 +198,42 @@ class MetadataLabelPredictionTask(BaseTask):
                     value=metrics_registry.compute(
                         MetricType.MEAN_FOLD_ACCURACY, results_df=results_df
                     ),
+                    params=common_params,
                 ),
                 MetricResult(
                     metric_type=MetricType.MEAN_FOLD_F1_SCORE,
                     value=metrics_registry.compute(
                         MetricType.MEAN_FOLD_F1_SCORE, results_df=results_df
                     ),
+                    params=common_params,
                 ),
                 MetricResult(
                     metric_type=MetricType.MEAN_FOLD_PRECISION,
                     value=metrics_registry.compute(
                         MetricType.MEAN_FOLD_PRECISION, results_df=results_df
                     ),
+                    params=common_params,
                 ),
                 MetricResult(
                     metric_type=MetricType.MEAN_FOLD_RECALL,
                     value=metrics_registry.compute(
                         MetricType.MEAN_FOLD_RECALL, results_df=results_df
                     ),
+                    params=common_params,
                 ),
                 MetricResult(
                     metric_type=MetricType.MEAN_FOLD_AUROC,
                     value=metrics_registry.compute(
                         MetricType.MEAN_FOLD_AUROC, results_df=results_df
                     ),
+                    params=common_params,
                 ),
             ]
         )
 
         # Calculate per-classifier metrics
         for clf in results_df["classifier"].unique():
+            params = {"classifier": clf, **common_params}
             metrics_list.extend(
                 [
                     MetricResult(
@@ -235,7 +243,7 @@ class MetadataLabelPredictionTask(BaseTask):
                             results_df=results_df,
                             classifier=clf,
                         ),
-                        params={"classifier": clf},
+                        params=params,
                     ),
                     MetricResult(
                         metric_type=MetricType.MEAN_FOLD_F1_SCORE,
@@ -244,7 +252,7 @@ class MetadataLabelPredictionTask(BaseTask):
                             results_df=results_df,
                             classifier=clf,
                         ),
-                        params={"classifier": clf},
+                        params=params,
                     ),
                     MetricResult(
                         metric_type=MetricType.MEAN_FOLD_PRECISION,
@@ -253,7 +261,7 @@ class MetadataLabelPredictionTask(BaseTask):
                             results_df=results_df,
                             classifier=clf,
                         ),
-                        params={"classifier": clf},
+                        params=params,
                     ),
                     MetricResult(
                         metric_type=MetricType.MEAN_FOLD_RECALL,
@@ -262,7 +270,7 @@ class MetadataLabelPredictionTask(BaseTask):
                             results_df=results_df,
                             classifier=clf,
                         ),
-                        params={"classifier": clf},
+                        params=params,
                     ),
                     MetricResult(
                         metric_type=MetricType.MEAN_FOLD_AUROC,
@@ -271,7 +279,7 @@ class MetadataLabelPredictionTask(BaseTask):
                             results_df=results_df,
                             classifier=clf,
                         ),
-                        params={"classifier": clf},
+                        params=params,
                     ),
                 ]
             )

--- a/src/czbenchmarks/tasks/single_cell/cross_species.py
+++ b/src/czbenchmarks/tasks/single_cell/cross_species.py
@@ -2,6 +2,7 @@ from typing import List, Set
 
 import numpy as np
 
+from ..constants import RANDOM_SEED
 from ...datasets import SingleCellDataset, DataType
 from ..base import BaseTask
 from ...metrics import metrics_registry
@@ -18,9 +19,11 @@ class CrossSpeciesIntegrationTask(BaseTask):
 
     Args:
         label_key: Key to access ground truth cell type labels in metadata
+        random_seed (int): Random seed for reproducibility
     """
 
-    def __init__(self, label_key: str):
+    def __init__(self, label_key: str, *, random_seed: int = RANDOM_SEED):
+        super().__init__(random_seed=random_seed)
         self.label_key = label_key
 
     @property

--- a/src/czbenchmarks/tasks/utils.py
+++ b/src/czbenchmarks/tasks/utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Literal
 
 import numpy as np
 import pandas as pd
@@ -27,10 +27,11 @@ TASK_NAMES = frozenset(
 def cluster_embedding(
     adata: AnnData,
     obsm_key: str = OBSM_KEY,
-    random_seed: int = RANDOM_SEED,
     n_iterations: int = 2,
-    flavor: str = FLAVOR,
+    flavor: Literal["leidenalg", "igraph"] = FLAVOR,
     key_added: str = KEY_ADDED,
+    *,
+    random_seed: int = RANDOM_SEED,
 ) -> List[int]:
     """Cluster cells in embedding space using the Leiden algorithm.
 
@@ -40,10 +41,10 @@ def cluster_embedding(
     Args:
         adata: AnnData object containing the embedding
         obsm_key: Key in adata.obsm containing the embedding coordinates
-        random_seed: Random seed for reproducibility
         n_iterations: Number of iterations for the Leiden algorithm
         flavor: Flavor of the Leiden algorithm
         key_added: Key in adata.obs to store the cluster assignments
+        random_seed (int): Random seed for reproducibility
     Returns:
         List of cluster assignments as integers
     """
@@ -103,7 +104,10 @@ def filter_minimum_class(
 
 
 def run_standard_scrna_workflow(
-    adata: AnnData, n_top_genes: int = 3000, n_pcs: int = 50, random_state: int = 42
+    adata: AnnData,
+    n_top_genes: int = 3000,
+    n_pcs: int = 50,
+    random_state: int = RANDOM_SEED,
 ) -> AnnData:
     """Run a standard preprocessing workflow for single-cell RNA-seq data.
 

--- a/tests/cli/test_cli_run.py
+++ b/tests/cli/test_cli_run.py
@@ -48,6 +48,11 @@ def test_main(mocker: MockFixture) -> None:
     mock_parse_task_args = mocker.patch(
         "czbenchmarks.cli.cli_run.parse_task_args", return_value=mock_task_args
     )
+    mock_aggregated_results = MagicMock()
+    mock_aggregate_results = mocker.patch(
+        "czbenchmarks.cli.cli_run.cli_utils.aggregate_task_results",
+        return_value=mock_aggregated_results,
+    )
 
     # Handle empty inputs
     main(
@@ -58,6 +63,7 @@ def test_main(mocker: MockFixture) -> None:
             output_file=None,
             output_format=None,
             batch_json=[],
+            batch_aggregate_metrics=False,
             remote_cache_url=None,
             remote_cache_upload="never",
             remote_cache_upload_results=False,
@@ -82,11 +88,13 @@ def test_main(mocker: MockFixture) -> None:
         cache_options=expected_cache_options,
     )
     mock_parse_task_args.assert_not_called()
+    mock_aggregate_results.assert_not_called()
 
     # Reset mocked functions
     mock_parse_task_args.reset_mock()
     mock_run.reset_mock()
     mock_write_results.reset_mock()
+    mock_aggregate_results.reset_mock()
 
     # Handle complex inputs
     main(
@@ -102,6 +110,7 @@ def test_main(mocker: MockFixture) -> None:
             output_file="output_file.yaml",
             output_format="yaml",
             batch_json=[""],
+            batch_aggregate_metrics=False,
             remote_cache_url="s3://cz-benchmarks-results-dev/test/",
             remote_cache_upload_embeddings=True,
             remote_cache_upload_results=True,
@@ -132,11 +141,13 @@ def test_main(mocker: MockFixture) -> None:
         cache_options=expected_cache_options,
     )
     assert mock_parse_task_args.call_count == 2
+    mock_aggregate_results.assert_not_called()
 
     # Reset mocked functions
     mock_parse_task_args.reset_mock()
     mock_run.reset_mock()
     mock_write_results.reset_mock()
+    mock_aggregate_results.reset_mock()
 
     # Handle batch inputs
     main(
@@ -150,6 +161,7 @@ def test_main(mocker: MockFixture) -> None:
                 '{"datasets": ["adamson_perturb"], "scgenept_dataset_name": ["adamson"], "scgenept_gene_pert": ["AEBPB+ctrl", "AEBPB+dox"]}',
                 '{"datasets": ["norman_perturb"], "scgenept_dataset_name": ["norman"], "scgenept_gene_pert": ["NTGC+ctrl", "NTGC+dox"]}',
             ],
+            batch_aggregate_metrics=True,
             remote_cache_url="s3://cz-benchmarks-results-dev/test/",
             remote_cache_download_embeddings=True,
             remote_cache_upload_embeddings=True,
@@ -194,6 +206,7 @@ def test_main(mocker: MockFixture) -> None:
             ),
         ]
     )
+    mock_aggregate_results.assert_called_once_with(mock_task_results)
 
 
 def test_run_with_inference(mocker: MockFixture) -> None:
@@ -216,7 +229,7 @@ def test_run_with_inference(mocker: MockFixture) -> None:
         return_value="test_dataset.dill",
     )
     mocker.patch(
-        "czbenchmarks.cli.cli_run.cli.get_version",
+        "czbenchmarks.cli.cli_run.cli_utils.get_version",
         return_value="0.0.0+test",
     )
     mocker.patch(
@@ -435,7 +448,9 @@ def test_run_task() -> None:
     mock_task_run_result = {
         ModelType.SCVI: [
             MetricResult(
-                metric_type=MetricType.ADJUSTED_RAND_INDEX, value=0.1, params={}
+                metric_type=MetricType.ADJUSTED_RAND_INDEX,
+                value=0.1,
+                params={"random_seed": 42},
             )
         ]
     }
@@ -457,7 +472,9 @@ def test_run_task() -> None:
             model_args={"model_variant": "homo_sapiens"},
             metrics=[
                 MetricResult(
-                    metric_type=MetricType.ADJUSTED_RAND_INDEX, value=0.1, params={}
+                    metric_type=MetricType.ADJUSTED_RAND_INDEX,
+                    value=0.1,
+                    params={"random_seed": 42},
                 )
             ],
         )
@@ -590,7 +607,7 @@ def test_set_processed_datasets_cache(mocker: MockFixture) -> None:
     )
     mock_dataset = MagicMock()
     mocker.patch(
-        "czbenchmarks.cli.cli_run.cli.get_version",
+        "czbenchmarks.cli.cli_run.cli_utils.get_version",
         return_value="0.0.0+test",
     )
     set_processed_datasets_cache(

--- a/tests/cli/test_cli_utils.py
+++ b/tests/cli/test_cli_utils.py
@@ -1,0 +1,152 @@
+import collections
+from unittest import mock
+
+import pytest
+
+from czbenchmarks.cli.utils import aggregate_task_results
+from czbenchmarks.cli.cli_run import TaskResult, DatasetDetail
+from czbenchmarks.metrics.types import AggregatedMetricResult, MetricResult
+from czbenchmarks.models.types import ModelType
+
+
+@mock.patch(
+    "czbenchmarks.cli.utils.metric_utils.aggregate_results",
+    return_value=[mock.MagicMock(spec=AggregatedMetricResult)],
+)
+def test_aggregate_task_results_same_key(mock_agg_metrics):
+    dummy_metrics = [
+        mock.MagicMock(spec=MetricResult) for _ in range(4)
+    ]  # there are separate tests for aggregating metrics so mock them
+    task_results = [
+        TaskResult(
+            task_name="dummy",
+            task_name_display="Dummy",
+            model_type=ModelType.SCVI,
+            model_args={"model_variant": "homo_sapiens"},
+            datasets=[DatasetDetail(name="dummy", organism="homo_sapiens")],
+            metrics=dummy_metrics[:2],
+            runtime_metrics={},
+        ),
+        TaskResult(
+            task_name="dummy",
+            task_name_display="Dummy",
+            model_type=ModelType.SCVI,
+            model_args={"model_variant": "homo_sapiens"},
+            datasets=[DatasetDetail(name="dummy", organism="homo_sapiens")],
+            metrics=dummy_metrics[2:],
+            runtime_metrics={},
+        ),
+    ]
+    agg_results = aggregate_task_results(task_results)
+
+    assert len(agg_results) == 1
+    assert agg_results[0].task_name == "dummy"
+    assert agg_results[0].task_name_display == "Dummy"
+    assert agg_results[0].model_type == ModelType.SCVI
+    assert agg_results[0].model_args == {"model_variant": "homo_sapiens"}
+    assert agg_results[0].datasets == [
+        DatasetDetail(name="dummy", organism="homo_sapiens")
+    ]
+    assert agg_results[0].metrics == mock_agg_metrics.return_value
+    mock_agg_metrics.assert_called_once_with(dummy_metrics)
+
+
+@mock.patch(
+    "czbenchmarks.cli.utils.metric_utils.aggregate_results",
+    return_value=[mock.MagicMock(spec=AggregatedMetricResult)],
+)
+def test_aggregate_task_results_different_key(mock_agg_metrics):
+    dummy_metrics = [
+        mock.MagicMock(spec=MetricResult) for _ in range(12)
+    ]  # there are separate tests for aggregating metrics so mock them
+    task_results = [
+        # all of these should aggregrate separately
+        TaskResult(
+            task_name="dummy",
+            task_name_display="Dummy",
+            model_type=ModelType.SCVI,
+            model_args={"model_variant": "homo_sapiens"},
+            datasets=[DatasetDetail(name="dummy", organism="homo_sapiens")],
+            metrics=dummy_metrics[:2],
+            runtime_metrics={},
+        ),
+        TaskResult(
+            task_name="extra",  # different task
+            task_name_display="Extra",
+            model_type=ModelType.SCVI,
+            model_args={"model_variant": "homo_sapiens"},
+            datasets=[DatasetDetail(name="dummy", organism="homo_sapiens")],
+            metrics=dummy_metrics[2:4],
+            runtime_metrics={},
+        ),
+        TaskResult(
+            task_name="dummy",
+            task_name_display="Dummy",
+            model_type=ModelType.SCGPT,  # different model
+            model_args={"model_variant": "human"},
+            datasets=[DatasetDetail(name="dummy", organism="homo_sapiens")],
+            metrics=dummy_metrics[4:6],
+            runtime_metrics={},
+        ),
+        TaskResult(
+            task_name="dummy",
+            task_name_display="Dummy",
+            model_type=ModelType.SCVI,
+            model_args={"model_variant": "mus_musculus"},  # different model_args
+            datasets=[DatasetDetail(name="dummy", organism="homo_sapiens")],
+            metrics=dummy_metrics[6:8],
+            runtime_metrics={},
+        ),
+        TaskResult(
+            task_name="dummy",
+            task_name_display="Dummy",
+            model_type=ModelType.SCVI,
+            model_args={"model_variant": "homo_sapiens"},
+            datasets=[
+                DatasetDetail(name="extended", organism="homo_sapiens")
+            ],  # different dataset name
+            metrics=dummy_metrics[8:10],
+            runtime_metrics={},
+        ),
+    ]
+    agg_results = aggregate_task_results(task_results)
+
+    assert len(agg_results) == 5
+    assert {"dummy": 4, "extra": 1} == collections.Counter(
+        [r.task_name for r in agg_results]
+    )
+    assert {ModelType.SCVI: 4, ModelType.SCGPT: 1} == collections.Counter(
+        [r.model_type for r in agg_results]
+    )
+    assert {"dummy": 4, "extended": 1} == collections.Counter(
+        [ds.name for r in agg_results for ds in r.datasets]
+    )
+    assert all(r.metrics == mock_agg_metrics.return_value for r in agg_results)
+    mock_agg_metrics.assert_has_calls(
+        [
+            mock.call(dummy_metrics[0:2]),
+            mock.call(dummy_metrics[2:4]),
+            mock.call(dummy_metrics[4:6]),
+            mock.call(dummy_metrics[6:8]),
+            mock.call(dummy_metrics[8:10]),
+        ],
+        any_order=True,
+    )
+
+
+def test_aggregate_task_results_empty():
+    assert aggregate_task_results([]) == []
+
+
+def test_aggregate_task_results_errors():
+    tr = TaskResult(
+        task_name="dummy",
+        task_name_display="Dummy",
+        model_type=ModelType.SCVI,
+        datasets=[],
+        model_args={},
+        metrics=[],
+        runtime_metrics={"gpu_mem": "123GiB"},
+    )
+    with pytest.raises(ValueError):
+        aggregate_task_results([tr])

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -1,7 +1,8 @@
 import pytest
 import numpy as np
 from enum import Enum
-from czbenchmarks.metrics.types import MetricType
+from czbenchmarks.metrics.types import MetricType, MetricResult
+from czbenchmarks.metrics.utils import aggregate_results
 
 
 def test_register_metric_valid(dummy_metric_registry, dummy_metric_function):
@@ -118,3 +119,91 @@ def test_metric_default_params(dummy_metric_registry, dummy_metric_function):
 
     info = dummy_metric_registry.get_info(MetricType.SILHOUETTE_SCORE)
     assert info.default_params == default_params
+
+
+def test_aggregate_results():
+    results = [
+        MetricResult(
+            metric_type=MetricType.SILHOUETTE_SCORE, params={"foo": 1}, value=0.30
+        ),
+        MetricResult(
+            metric_type=MetricType.SILHOUETTE_SCORE, params={"foo": 1}, value=0.50
+        ),
+        MetricResult(
+            metric_type=MetricType.SILHOUETTE_SCORE, params={"foo": 2}, value=0.60
+        ),
+        MetricResult(
+            metric_type=MetricType.SILHOUETTE_SCORE, params={"foo": 2}, value=0.80
+        ),
+        MetricResult(metric_type=MetricType.ADJUSTED_RAND_INDEX, value=0.10),
+        MetricResult(metric_type=MetricType.ADJUSTED_RAND_INDEX, params={}, value=0.90),
+    ]
+    agg_results = aggregate_results(results)
+    assert len(agg_results) == 3
+
+    # there should be two silhoutte score aggregated results since there are two different params
+    try:
+        ss_foo1_result = next(
+            r
+            for r in agg_results
+            if r.metric_type == MetricType.SILHOUETTE_SCORE and r.params == {"foo": 1}
+        )
+    except StopIteration:
+        pytest.fail(
+            "No aggregated result for MetricType.SILHOUETTE_SCORE with params {'foo': 1}"
+        )
+    assert ss_foo1_result.value == pytest.approx(0.40, abs=1e-2)
+    assert ss_foo1_result.value_std_dev == pytest.approx(0.1414, abs=1e-4)
+    assert ss_foo1_result.values_raw == [0.30, 0.50]
+    assert ss_foo1_result.n_values == 2
+
+    try:
+        ss_foo2_result = next(
+            r
+            for r in agg_results
+            if r.metric_type == MetricType.SILHOUETTE_SCORE and r.params == {"foo": 2}
+        )
+    except StopIteration:
+        pytest.fail(
+            "No aggregated result for MetricType.SILHOUETTE_SCORE with params {'foo': 2}"
+        )
+    assert ss_foo2_result.value == pytest.approx(0.70, abs=1e-2)
+    assert ss_foo2_result.value_std_dev == pytest.approx(0.1414, abs=1e-4)
+    assert ss_foo2_result.values_raw == [0.60, 0.80]
+    assert ss_foo2_result.n_values == 2
+
+    # both should be aggregated togeter since params is empty
+    try:
+        ari_result = next(
+            r for r in agg_results if r.metric_type == MetricType.ADJUSTED_RAND_INDEX
+        )
+    except StopIteration:
+        pytest.fail("No aggregated result for MetricType.ADJUSTED_RAND_INDEX")
+    assert not ari_result.params
+    assert ari_result.value == pytest.approx(0.50, abs=1e-2)
+    assert ari_result.value_std_dev == pytest.approx(0.5657, abs=1e-4)
+    assert ari_result.values_raw == [0.10, 0.90]
+    assert ari_result.n_values == 2
+
+
+def test_aggregate_results_works_on_empty():
+    assert aggregate_results([]) == []
+
+
+def test_aggregate_results_handles_just_one():
+    results = [
+        MetricResult(
+            metric_type=MetricType.SILHOUETTE_SCORE, params={"foo": 2}, value=0.42
+        )
+    ]
+    agg_results = aggregate_results(results)
+
+    assert len(agg_results) == 1
+    agg_result = agg_results[0]
+
+    assert agg_result.metric_type == MetricType.SILHOUETTE_SCORE
+    assert agg_result.params == {"foo": 2}
+    assert agg_result.value == pytest.approx(0.42)
+    assert agg_result.value_std_dev is None
+    assert agg_result.values_raw == [0.42]
+    assert agg_result.n_values == 1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ import anndata as ad
 import scipy.sparse as sp
 
 from czbenchmarks.datasets.types import Organism
+from czbenchmarks.tasks.constants import RANDOM_SEED
 from typing import List, Set
 from czbenchmarks.tasks.base import BaseTask
 from czbenchmarks.datasets import (
@@ -81,7 +82,10 @@ class DummyDataset(BaseDataset):
 class DummyTask(BaseTask):
     """A dummy task implementation for testing."""
 
-    def __init__(self, requires_multiple: bool = False):
+    def __init__(
+        self, requires_multiple: bool = False, *, random_seed: int = RANDOM_SEED
+    ):
+        super().__init__(random_seed=random_seed)
         self._requires_multiple = requires_multiple
 
     @property


### PR DESCRIPTION
- add clustering CLI argument for specifying seed
- rename label prediction CLI argument to match task arguments
- persist the random seed in the metric result params
- fix a type annotation on clustering

I'm not sure who the best group is to review this. This was suggested as something small to get me a little more familiar with the library.

Questions I have:

1. the other tasks don't seem to use a random seed as far as I can tell, so I only plumbed up these ones. Is that correct or should I dig deeper into the other libraries they're invoking?
2. there's a `set_baseline` method on every task that does use a random seed, but I don't understand how this fits in with this ticket to know if I need to do something with that
3. am I using `params` correctly for the metric results? Or is there a better way to capture the random seed? Or do I need to implement something else?