### PR TITLE
fix: Push transcriptformer docker image to ECR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,6 +35,8 @@ jobs:
             custom_tag: scgpt
           - dockerfile: docker/geneformer/Dockerfile
             custom_tag: geneformer
+          - dockerfile: docker/transcriptformer/Dockerfile
+            custom_tag: transcriptformer
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4


### PR DESCRIPTION
This should build the docker image and push it to ECR and be viewable here:

https://gallery.ecr.aws/y4c8w5f9/cz-benchmarks-models-public