### PR TITLE
chore: add convenience fields to the CLI output (VC-2622)

### DIFF
--- a/docs/source/developer_guides/tasks.md
+++ b/docs/source/developer_guides/tasks.md
@@ -43,6 +43,7 @@ To define a new evaluation task:
 
 2. **Override the following methods:**
 
+   - `display_name`: a human-readable string naming your task, used for display purposes
    - `required_inputs`: a set of `DataType` values required as inputs
    - `required_outputs`: a set of `DataType` values expected as model outputs
    - `_run_task(data, model_type)`: executes task logic using input data and model outputs
@@ -64,6 +65,10 @@ To define a new evaluation task:
    from czbenchmarks.metrics.types import MetricResult
 
    class MyNewTask(BaseTask):
+       @property
+       def display_name(self):
+           return "My New Task"
+
        @property
        def required_inputs(self):
            return {DataType.METADATA}

--- a/docs/source/how_to_guides/add_custom_model.md
+++ b/docs/source/how_to_guides/add_custom_model.md
@@ -42,6 +42,8 @@ In the `src.czbenchmarks.models.types.ModelType` enum, add a value for your mode
           YOUR_MODEL = "YOUR_MODEL"
      ```
 
+---
+
 ## Step 3: Implement the Model Class
 
 1. Create a model class that extends `BaseModelImplementation`.
@@ -58,10 +60,10 @@ In the `src.czbenchmarks.models.types.ModelType` enum, add a value for your mode
 
 
      class YourModel(BaseModelImplementation):
-          def parse_args(self):
+          def create_parser(self):
                parser = argparse.ArgumentParser(description="Run YourModel on input dataset.")
                parser.add_argument("--your_param", type=int, default=32, help="Description of your_param")
-               return parser.parse_args()
+               return parser
 
           model_type = ModelType.YOUR_MODEL
 
@@ -95,7 +97,29 @@ Note that you can access any arguments specified in the `config.yaml` or via com
 
 ---
 
-## Step 4: (Optional) Extend `BaseSingleCellValidator`
+## Step 4: (Optional) Add a display name for your Model
+
+In `src.czbenchmarks.models.utils`, add a display name for your model if you would
+like a prettier display name than the one you used in the `ModelType` enum.
+
+As currently implemented, the display name can be customized based on the value in the
+`ModelType` enum as well as the `model-variant` and (fine-tuning) `dataset` arguments
+passed to your model (defined in the `create_parser` method).
+
+
+    Example:
+
+     ```python
+     _MODEL_VARIANT_FINETUNE_TO_DISPLAY_NAME = {
+         ...
+         ("YOUR_MODEL", "1M10L", None): "YourModel (1 million cells, 10 layers)",
+         ...
+     }
+     ```
+
+---
+
+## Step 5: (Optional) Extend `BaseSingleCellValidator`
 
 If your model is a single-cell transcriptomic model and accepts AnnData objects as input, then it can extend `BaseSingleCellValidator`. This will enable the class to validate that the input `Dataset` provides the required organisms, obs keys, and var keys.
 
@@ -127,7 +151,7 @@ If your model is a single-cell transcriptomic model and accepts AnnData objects 
 
 ---
 
-## Step 5: Create a Config File for the Model
+## Step 6: Create a Config File for the Model
 
 1. Create a `config.yaml` file in your model's directory. This file will define the configuration parameters required for your model.
 2. Include the `_target_` key to specify the model class and any additional parameters your model requires.
@@ -144,14 +168,14 @@ If your model is a single-cell transcriptomic model and accepts AnnData objects 
 
 ---
 
-## Step 6: Add `requirements.txt`
+## Step 7: Add `requirements.txt`
 
 1. Create a `requirements.txt` file under `docker/your_model`.
 2. Add required Python packages
 
 ---
 
-## Step 7: Create a `Dockerfile`
+## Step 8: Create a `Dockerfile`
 
 1. Create a new file `docker/your_model/Dockerfile`
 2. Specify Docker commands to build the Docker image, per the requirments of the model.
@@ -195,7 +219,7 @@ If your model is a single-cell transcriptomic model and accepts AnnData objects 
 
 ---
 
-## Step 8: Build Your Model
+## Step 9: Build Your Model
 
 1. Build the Docker container using the `Dockerfile` you created. Run the following command, replacing `your_model` with the appropriate values:
 
@@ -213,7 +237,7 @@ If your model is a single-cell transcriptomic model and accepts AnnData objects 
 
 ---
 
-## Step 9: Test Your Model
+## Step 10: Test Your Model
 
 Test the Docker container to ensure it works as expected. You can run the container and verify its functionality by executing your model on a sample dataset using the `czbenchmarks.runner.run_inference()` method.
 

--- a/docs/source/how_to_guides/add_new_task.md
+++ b/docs/source/how_to_guides/add_new_task.md
@@ -22,6 +22,10 @@ This guide explains how to create and integrate your own evaluation task into cz
             self.my_param = my_param
 
         @property
+        def display_name(self) -> str:
+            return "My Example Task"
+
+        @property
         def required_inputs(self) -> Set[DataType]:
             return {DataType.METADATA}
 
@@ -43,6 +47,7 @@ This guide explains how to create and integrate your own evaluation task into cz
     ```
 
 - Consult `czbenchmarks/tasks/base.py` for interface details and best practices.
+- Use `display_name` to provide a human-readable name for use when displaying your task
 - Use the `required_inputs` and `required_outputs` properties to specify the data types your task needs.
     - `required_inputs`: Data your task consumes (e.g., `DataType.METADATA`).
     - `required_outputs`: Data your task produces or depends on (e.g., `DataType.EMBEDDING`).

--- a/src/czbenchmarks/datasets/utils.py
+++ b/src/czbenchmarks/datasets/utils.py
@@ -124,3 +124,57 @@ def list_available_datasets() -> List[str]:
     dataset_names.sort()
 
     return dataset_names
+
+
+_DATASET_TO_DISPLAY_NAME = {
+    "adamson_perturb": "Adamson",
+    "norman_perturb": "Norman",
+    "dixit_perturb": "Dixit",
+    "replogle_k562_perturb": "Replogle K562",
+    "replogle_rpe1_perturb": "Replogle RPE1",
+    "human_spermatogenesis": "Spermatogenesis - Homo sapiens",
+    "mouse_spermatogenesis": "Spermatogenesis - Mus musculus",
+    "rhesus_macaque_spermatogenesis": "Spermatogenesis - Macaca mulatta",
+    "gorilla_spermatogenesis": "Spermatogenesis - Gorilla gorilla",
+    "chimpanzee_spermatogenesis": "Spermatogenesis - Pan troglodytes",
+    "marmoset_spermatogenesis": "Spermatogenesis - Callithrix jacchus",
+    "chicken_spermatogenesis": "Spermatogenesis - Gallus gallus",
+    "opossum_spermatogenesis": "Spermatogenesis - Monodelphis domestica",
+    "platypus_spermatogenesis": "Spermatogenesis - Ornithorhynchus anatinus",
+    "tsv2_bladder": "Tabula Sapiens 2.0 - Bladder",
+    "tsv2_blood": "Tabula Sapiens 2.0 - Blood",
+    "tsv2_bone_marrow": "Tabula Sapiens 2.0 - Bone marrow",
+    "tsv2_ear": "Tabula Sapiens 2.0 - Ear",
+    "tsv2_eye": "Tabula Sapiens 2.0 - Eye",
+    "tsv2_fat": "Tabula Sapiens 2.0 - Fat",
+    "tsv2_heart": "Tabula Sapiens 2.0 - Heart",
+    "tsv2_large_intestine": "Tabula Sapiens 2.0 - Large intestine",
+    "tsv2_liver": "Tabula Sapiens 2.0 - Liver",
+    "tsv2_lung": "Tabula Sapiens 2.0 - Lung",
+    "tsv2_lymph_node": "Tabula Sapiens 2.0 - Lymph node",
+    "tsv2_mammary": "Tabula Sapiens 2.0 - Mammary",
+    "tsv2_muscle": "Tabula Sapiens 2.0 - Muscle",
+    "tsv2_ovary": "Tabula Sapiens 2.0 - Ovary",
+    "tsv2_prostate": "Tabula Sapiens 2.0 - Prostate",
+    "tsv2_salivary_gland": "Tabula Sapiens 2.0 - Salivary gland",
+    "tsv2_skin": "Tabula Sapiens 2.0 - Skin",
+    "tsv2_small_intestine": "Tabula Sapiens 2.0 - Small intestine",
+    "tsv2_spleen": "Tabula Sapiens 2.0 - Spleen",
+    "tsv2_stomach": "Tabula Sapiens 2.0 - Stomach",
+    "tsv2_testis": "Tabula Sapiens 2.0 - Testis",
+    "tsv2_thymus": "Tabula Sapiens 2.0 - Thymus",
+    "tsv2_tongue": "Tabula Sapiens 2.0 - Tongue",
+    "tsv2_trachea": "Tabula Sapiens 2.0 - Trachea",
+    "tsv2_uterus": "Tabula Sapiens 2.0 - Uterus",
+    "tsv2_vasculature": "Tabula Sapiens 2.0 - Vasculature",
+}
+
+
+def dataset_to_display_name(dataset_name: str) -> str:
+    """try to map dataset names to more uniform, pretty strings"""
+    try:
+        return _DATASET_TO_DISPLAY_NAME[dataset_name]
+    except KeyError:
+        # e.g. "my_awesome_dataset" -> "My awesome dataset"
+        parts = dataset_name.split("_")
+        return " ".join((parts[0].title(), *(part.lower() for part in parts[1:])))

--- a/src/czbenchmarks/models/types.py
+++ b/src/czbenchmarks/models/types.py
@@ -1,6 +1,11 @@
 from enum import Enum
-from typing import Dict
-from ..datasets.types import DataType, DataValue
+from typing import Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..datasets.types import DataType, DataValue
+else:
+    DataType = "DataType"
+    DataValue = "DataValue"
 
 
 class ModelType(Enum):
@@ -24,7 +29,7 @@ class ModelType(Enum):
         return self.name
 
     def __repr__(self):
-        return self.name
+        return f"{self.__class__.__name__}.{self.value}"
 
 
 # Type alias for model outputs

--- a/src/czbenchmarks/models/utils.py
+++ b/src/czbenchmarks/models/utils.py
@@ -1,7 +1,13 @@
+import logging
 from typing import List
 import hydra
 from omegaconf import OmegaConf
+
+from .types import ModelType
 from ..utils import initialize_hydra
+
+
+logger = logging.getLogger(__name__)
 
 
 def list_available_models() -> List[str]:
@@ -23,3 +29,98 @@ def list_available_models() -> List[str]:
     model_names.sort()
 
     return model_names
+
+
+_MODEL_VARIANT_FINETUNE_TO_DISPLAY_NAME = {  # maps a tuple of (name, variant, fine_tune_dataset) to a display name
+    # AIDO
+    ("AIDO", "aido_cell_3m", None): "AIDO.Cell-3M",
+    # Geneformer
+    ("GENEFORMER", "gf_6L_30M", None): "GF-6L-30M-i2048 (June 2021)",
+    ("GENEFORMER", "gf_12L_30M", None): "GF-12L-30M-i2048 (June 2021)",
+    ("GENEFORMER", "gf_12L_95M", None): "GF-12L-95M-i4096 (April 2024)",
+    ("GENEFORMER", "gf_20L_95M", None): "GF-20L-95M-i4096 (April 2024)",
+    # scGenePT
+    (
+        "SCGENEPT",
+        "scgenept_ncbi_gpt",
+        "adamson",
+    ): "scGenePT_{NCBI}, fine-tuned, Adamson",
+    ("SCGENEPT", "scgenept_ncbi_gpt", "norman"): "scGenePT_{NCBI}, fine-tuned, Norman",
+    (
+        "SCGENEPT",
+        "scgenept_ncbi+uniprot_gpt",
+        "adamson",
+    ): "scGenePT_{NCBI+UniProt}, fine-tuned, Adamson",
+    (
+        "SCGENEPT",
+        "scgenept_ncbi+uniprot_gpt",
+        "norman",
+    ): "scGenePT_{NCBI+UniProt}, fine-tuned, Norman",
+    (
+        "SCGENEPT",
+        "scgenept_go_f_gpt_concat",
+        "adamson",
+    ): "scGenePT_{GO-F}, fine-tuned, Adamson",
+    (
+        "SCGENEPT",
+        "scgenept_go_f_gpt_concat",
+        "norman",
+    ): "scGenePT_{GO-F}, fine-tuned, Norman",
+    (
+        "SCGENEPT",
+        "scgenept_go_p_gpt_concat",
+        "adamson",
+    ): "scGenePT_{GO-P}, fine-tuned, Adamson",
+    (
+        "SCGENEPT",
+        "scgenept_go_p_gpt_concat",
+        "norman",
+    ): "scGenePT_{GO-P}, fine-tuned, Norman",
+    (
+        "SCGENEPT",
+        "scgenept_go_c_gpt_concat",
+        "adamson",
+    ): "scGenePT_{GO-C}, fine-tuned, Adamson",
+    (
+        "SCGENEPT",
+        "scgenept_go_c_gpt_concat",
+        "norman",
+    ): "scGenePT_{GO-C}, fine-tuned, Norman",
+    (
+        "SCGENEPT",
+        "scgenept_go_all_gpt_concat",
+        "adamson",
+    ): "scGenePT_{GO-all}, fine-tuned, Adamson",
+    (
+        "SCGENEPT",
+        "scgenept_go_all_gpt_concat",
+        "norman",
+    ): "scGenePT_{GO-all}, fine-tuned, Norman",
+    # scGPT
+    ("SCGPT", "human", None): "scGPT - whole-human",
+    # scVI
+    ("SCVI", "homo_sapiens", None): "scVI, Census 2023-12-15, homo sapiens",
+    # Transcriptformer
+    ("TRANSCRIPTFORMER", "tf-sapiens", None): "TF-Sapiens",
+    ("TRANSCRIPTFORMER", "tf-exemplar", None): "TF-Exemplar",
+    ("TRANSCRIPTFORMER", "tf-metazoa", None): "TF-Metazoa",
+    # UCE
+    ("UCE", "4l", None): "UCE-4L",
+    ("UCE", "33l", None): "UCE-33L",
+}
+
+
+def model_to_display_name(
+    model_type: ModelType, model_args: dict[str, str | int]
+) -> str:
+    """try to map the model variant names to more uniform, pretty strings"""
+    key = (model_type.name, model_args.get("model_variant"), model_args.get("dataset"))
+
+    try:
+        return _MODEL_VARIANT_FINETUNE_TO_DISPLAY_NAME[key]
+    except KeyError:
+        if model_args:
+            logger.warning(
+                "No display name provided for %r. Using title-case.", model_type
+            )
+        return model_type.name.title()

--- a/src/czbenchmarks/tasks/base.py
+++ b/src/czbenchmarks/tasks/base.py
@@ -21,6 +21,11 @@ class BaseTask(ABC):
 
     @property
     @abstractmethod
+    def display_name(self) -> str:
+        """A pretty name to use when displaying task results"""
+
+    @property
+    @abstractmethod
     def required_inputs(self) -> Set[DataType]:
         """Required input data types this task requires.
 

--- a/src/czbenchmarks/tasks/clustering.py
+++ b/src/czbenchmarks/tasks/clustering.py
@@ -38,6 +38,11 @@ class ClusteringTask(BaseTask):
         self.key_added = key_added
 
     @property
+    def display_name(self) -> str:
+        """A pretty name to use when displaying task results"""
+        return "clustering"
+
+    @property
     def required_inputs(self) -> Set[DataType]:
         """Required input data types.
 

--- a/src/czbenchmarks/tasks/embedding.py
+++ b/src/czbenchmarks/tasks/embedding.py
@@ -24,6 +24,11 @@ class EmbeddingTask(BaseTask):
         self.label_key = label_key
 
     @property
+    def display_name(self) -> str:
+        """A pretty name to use when displaying task results"""
+        return "embedding"
+
+    @property
     def required_inputs(self) -> Set[DataType]:
         """Required input data types.
 

--- a/src/czbenchmarks/tasks/integration.py
+++ b/src/czbenchmarks/tasks/integration.py
@@ -26,6 +26,11 @@ class BatchIntegrationTask(BaseTask):
         self.batch_key = batch_key
 
     @property
+    def display_name(self) -> str:
+        """A pretty name to use when displaying task results"""
+        return "batch integration"
+
+    @property
     def required_inputs(self) -> Set[DataType]:
         """Required input data types.
 

--- a/src/czbenchmarks/tasks/label_prediction.py
+++ b/src/czbenchmarks/tasks/label_prediction.py
@@ -60,6 +60,11 @@ class MetadataLabelPredictionTask(BaseTask):
         )
 
     @property
+    def display_name(self) -> str:
+        """A pretty name to use when displaying task results"""
+        return "metadata label prediction"
+
+    @property
     def required_inputs(self) -> Set[DataType]:
         """Required input data types.
 

--- a/src/czbenchmarks/tasks/single_cell/cross_species.py
+++ b/src/czbenchmarks/tasks/single_cell/cross_species.py
@@ -24,6 +24,11 @@ class CrossSpeciesIntegrationTask(BaseTask):
         self.label_key = label_key
 
     @property
+    def display_name(self) -> str:
+        """A pretty name to use when displaying task results"""
+        return "cross-species integration"
+
+    @property
     def required_inputs(self) -> Set[DataType]:
         """Required input data types.
 

--- a/src/czbenchmarks/tasks/single_cell/perturbation.py
+++ b/src/czbenchmarks/tasks/single_cell/perturbation.py
@@ -22,6 +22,11 @@ class PerturbationTask(BaseTask):
     """
 
     @property
+    def display_name(self) -> str:
+        """A pretty name to use when displaying task results"""
+        return "perturbation"
+
+    @property
     def required_inputs(self) -> Set[DataType]:
         """Required input data types.
 

--- a/tests/cli/test_cli_e2e_workflow.py
+++ b/tests/cli/test_cli_e2e_workflow.py
@@ -41,7 +41,7 @@ def test_cli_e2e_workflow(mock_runner):
     model_name = "SCGPT"
     model_type = ModelType.SCGPT
     model_args = [
-        ModelArgs(name=model_name, args={}),
+        ModelArgs(name=model_name, args={"model_variant": ["human"]}),
     ]
     task_args = [
         TaskArgs(
@@ -71,9 +71,13 @@ def test_cli_e2e_workflow(mock_runner):
 
     # Verify basic task result fields
     assert task_result.task_name == task_name
+    assert task_result.task_name_display == "embedding"
     assert task_result.model_type == model_type
-    assert task_result.dataset_name == dataset_name
-    assert task_result.model_args == {}, "Expected empty model args"
+    assert task_result.dataset_names == [dataset_name]
+    assert task_result.dataset_names_display == ["Spermatogenesis - Gallus gallus"]
+    assert task_result.model_args == {"model_variant": "human"}
+    assert task_result.model_name_display == "scGPT - whole-human"
+    assert task_result.runtime_metrics == {}, "Expected no runtime metrics"
 
     # Verify metrics
     assert isinstance(task_result.metrics, list)

--- a/tests/cli/test_cli_run.py
+++ b/tests/cli/test_cli_run.py
@@ -37,6 +37,7 @@ def test_main(mocker: MockFixture) -> None:
         return_value=None,
     )
     mock_task_args = MagicMock()
+    mock_task_args.task = MagicMock()
     mock_parse_task_args = mocker.patch(
         "czbenchmarks.cli.cli_run.parse_task_args", return_value=mock_task_args
     )
@@ -350,6 +351,8 @@ def test_run_task() -> None:
     }
     mock_task_args = MagicMock()
     mock_task_args.name = "clustering"
+    mock_task_args.task = MagicMock()
+    mock_task_args.task.display_name = "clustering"
     mock_task_run_result = {
         ModelType.SCVI: [
             MetricResult(
@@ -369,8 +372,10 @@ def test_run_task() -> None:
     assert task_results == [
         TaskResult(
             task_name="clustering",
+            task_name_display="clustering",
             model_type="SCVI",
-            dataset_name="tsv2_heart",
+            dataset_names=["tsv2_heart"],
+            dataset_names_display=["Tabula Sapiens 2.0 - Heart"],
             model_args={"model_variant": "homo_sapiens"},
             metrics=[
                 MetricResult(
@@ -390,6 +395,8 @@ def test_run_multi_dataset_task() -> None:
     mock_task_args = MagicMock()
     mock_task_args.name = "cross_species"
     mock_task_args.set_baseline = False
+    mock_task_args.task = MagicMock()
+    mock_task_args.task.display_name = "cross-species integration"
     mock_dataset_names = ["human_spermatogenesis", "mouse_spermatogenesis"]
     mock_task_run_result = {
         ModelType.UCE: [
@@ -409,8 +416,13 @@ def test_run_multi_dataset_task() -> None:
     assert task_results == [
         TaskResult(
             task_name="cross_species",
+            task_name_display="cross-species integration",
             model_type="UCE",
-            dataset_name=",".join(mock_dataset_names),
+            dataset_names=list(sorted(mock_dataset_names)),
+            dataset_names_display=[
+                "Spermatogenesis - Homo sapiens",
+                "Spermatogenesis - Mus musculus",
+            ],
             model_args={"model_variant": "4l"},
             metrics=[
                 MetricResult(

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -1,10 +1,10 @@
-from czbenchmarks.datasets.utils import list_available_datasets
+from czbenchmarks.datasets import utils
 
 
 def test_list_available_datasets():
     """Test that list_available_datasets returns a sorted list of dataset names."""
     # Get the list of available datasets
-    datasets = list_available_datasets()
+    datasets = utils.list_available_datasets()
 
     # Verify it's a list
     assert isinstance(datasets, list)
@@ -20,3 +20,19 @@ def test_list_available_datasets():
 
     # Verify no empty strings
     assert all(len(dataset) > 0 for dataset in datasets)
+
+
+def test_dataset_to_display_name():
+    """Test that we genererate dataset display names properly"""
+    # test that the formulaic formatting works
+    assert "My dataset" == utils.dataset_to_display_name("my_dataset")
+    assert "Example dataset" == utils.dataset_to_display_name("EXAMPLE_DATASET")
+    assert "Short" == utils.dataset_to_display_name("short")
+    assert "This is a really long one" == utils.dataset_to_display_name(
+        "This_is_A_ReAlLy_loNG_ONE"
+    )
+    assert "" == utils.dataset_to_display_name("")
+
+    # test that special case lookup works too
+    for k, v in utils._DATASET_TO_DISPLAY_NAME.items():
+        assert v == utils.dataset_to_display_name(k)

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -1,10 +1,12 @@
-from czbenchmarks.models.utils import list_available_models
+from collections import namedtuple
+
+from czbenchmarks.models import utils
 
 
 def test_list_available_models():
     """Test that list_available_models returns a sorted list of model names."""
     # Get the list of available datasets
-    models = list_available_models()
+    models = utils.list_available_models()
 
     # Verify it's a list
     assert isinstance(models, list)
@@ -20,3 +22,26 @@ def test_list_available_models():
 
     # Verify no empty strings
     assert all(len(model) > 0 for model in models)
+
+
+def test_model_to_display_name():
+    """Test that we generate model variant display names properly"""
+    DummyModelType = namedtuple("DummyModelType", ["name"])
+    dummy_model_type = DummyModelType("TESTER")
+
+    # test that the formulaic formatting works
+    assert "Tester" == utils.model_to_display_name(dummy_model_type, {})
+    assert "Tester" == utils.model_to_display_name(
+        dummy_model_type, {"model_variant": "A1"}
+    )
+    assert "Tester" == utils.model_to_display_name(
+        dummy_model_type, {"model_variant": "A1", "dataset": "good_cells"}
+    )
+
+    # test that special case lookup works too
+    for k, v in utils._MODEL_VARIANT_FINETUNE_TO_DISPLAY_NAME.items():
+        dummy_model_type = DummyModelType(k[0])
+        args = {"model_variant": k[1]}
+        if k[2] is not None:
+            args["dataset"] = k[2]
+        assert v == utils.model_to_display_name(dummy_model_type, args)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -85,6 +85,10 @@ class DummyTask(BaseTask):
         self._requires_multiple = requires_multiple
 
     @property
+    def display_name(self) -> str:
+        return "dummy task"
+
+    @property
     def required_inputs(self) -> Set[DataType]:
         return {DataType.ANNDATA, DataType.METADATA}
 


### PR DESCRIPTION
- add util functions to models and datasets to translate the nonstandardized names to human-readable ones
- add some tests for these
- add a display_name property to all tasks
- update the CLI to include human-readable display names in the output
- update the CLI to include runtime metrics per task in the output
- update the CLI tests to use and check the new fields