### PR TITLE
chore: pin model package versions

### DIFF
--- a/docker/scgenept/Dockerfile
+++ b/docker/scgenept/Dockerfile
@@ -5,10 +5,13 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get install -y python3 python3-pip git
 
-RUN git clone https://github.com/czi-ai/scGenePT.git && \
+RUN git clone --depth 1 https://github.com/czi-ai/scGenePT.git && \
+    (cd scGenePT && \
+     git fetch --depth=1 origin 5847c57e4cccd9949a7f0b5f3775d5dcae5a5eac && \
+     git checkout 5847c57e4cccd9949a7f0b5f3775d5dcae5a5eac) && \ 
     mv scGenePT/* . && rm -rf scGenePT && \
     pip install --no-cache-dir -r requirements.txt && \
-    pip install scgpt    
+    pip install scgpt==0.2.4
 
 # Install the czbenchmarks package
 COPY src /app/package/src

--- a/docker/transcriptformer/Dockerfile
+++ b/docker/transcriptformer/Dockerfile
@@ -8,10 +8,10 @@ RUN apt-get update && \
 # Clone the repository and install
 RUN apt-get install -y curl && \
     pip install uv && \
-    git clone https://github.com/czi-ai/transcriptformer.git && \
+    git clone --branch v0.1.0 --depth 1 https://github.com/czi-ai/transcriptformer.git && \
     cd transcriptformer && \
     uv venv --python=3.11 && \
-    . .venv/bin/activate && \
+    . .venv/bin/activate && \   
     uv pip install -e .
 
 COPY src /app/package/src

--- a/docker/uce/Dockerfile
+++ b/docker/uce/Dockerfile
@@ -25,10 +25,11 @@ RUN conda create -n uce python=3.11 -y && \
 
 # Clone the UCE repository and install UCE
 # TODO: clone / install somewhere that won't be squashed by code mounting
-RUN git clone https://github.com/giovp/UCE && \
-    cd UCE && \
-    /opt/conda/envs/uce/bin/pip install . && \
-    cd ..
+RUN git clone --depth 1 https://github.com/giovp/UCE && \
+    (cd UCE && \
+     git fetch --depth=1 origin dc5421593920b821f789a21a7aae308ac237f908 && \
+     git checkout dc5421593920b821f789a21a7aae308ac237f908 && \
+    /opt/conda/envs/uce/bin/pip install .)
 
 # Install the czbenchmarks package
 COPY src /app/package/src
@@ -44,6 +45,7 @@ RUN mkdir -p /app/model_files && \
 RUN ln -s /weights/model_files/protein_embeddings /app/model_files/protein_embeddings
 
 # Install base requirements
+# Note: this overrides some package versions specified by the UCE repo that were previously installed.
 COPY docker/uce/requirements.txt .
 RUN /opt/conda/envs/uce/bin/pip install -r requirements.txt
 


### PR DESCRIPTION
For https://czi.atlassian.net/browse/VC-2611

For UCE, scGenePT, and Transcriptformer, the Docker build now pins the Git repo commit and/or pypi package versions used to build the model image. This will prevent unintentional changes if/when the repo or pypi packages are updated.

The pinned versions were confirmed to be the active versions at the time of the last benchmarking run, based upon the embedding creation dates.

Model images were tested to ensure the model runs to the point of starting inference (but not to completion).