### PR TITLE
chore: Add Readme for pypi

### DIFF
--- a/README-pypi.md
+++ b/README-pypi.md
@@ -2,7 +2,7 @@
 
 ## PROJECT STATUS: UNSTABLE
 
-⚠️ **Warning:** Repository under active development and is in the alpha phase of development, subject to major refactors as outlined in the public-facing [roadmap](docs/source/roadmap.md).
+⚠️ **Warning:** Repository under active development and is in the alpha phase of development, subject to major refactors as outlined in the public-facing [roadmap](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/roadmap.md).
 
 ### What is cz-benchmarks?
 cz-benchmarks is a package for standardized evaluation and comparison of machine learning models for biological applications (first, in the single-cell transcriptomics domain, with future plans to expand to additional domains). The package provides a toolkit for running containerized models, executing biologically-relevant tasks, and computing performance metrics. We see this tool as a step towards ensuring that large-scale AI models can be harnessed to deliver genuine biological insights -- by building trust, accelerating development, and bridging the gap between ML and biology communities.
@@ -13,35 +13,18 @@ Last year, CZI hosted a workshop focused on benchmarking and evaluation of AI mo
 ### 💬 Community Feedback & Contributions
 We're working to get the alpha version of cz-benchmarks stable to build with the community. In the meantime, for issues you may identify, feel free to open an issue on GitHub or reach out to us at [virtualcellmodels@chanzuckerberg.com](mailto:virtualcellmodels@chanzuckerberg.com).
 
+## Getting Started
 
-## Table of contents
+To get started with `cz-benchmarks`, refer to the [Quick Start Guide](https://chanzuckerberg.github.io/cz-benchmarks/quick_start.html).
 
-### Getting Started
-- [Quick Start Guide](docs/source/quick_start.md)
 
-### How-To Guides
-- [Add a Custom Dataset](docs/source/how_to_guides/add_custom_dataset.md)
-- [Add a Custom Model](docs/source/how_to_guides/add_custom_model.md)
-- [Add a New Metric](docs/source/how_to_guides/add_new_metric.md)
-- [Add a New Task](docs/source/how_to_guides/add_new_task.md)
-- [Interactive Mode](docs/source/how_to_guides/interactive_mode.md)
-- [Visualize Results](docs/source/how_to_guides/visualize_results.md)
+### 📚 Additional Resources
 
-### Developer Guides
-- [Datasets](docs/source/developer_guides/datasets.md)
-- [Metrics](docs/source/developer_guides/metrics.md)
-- [Models](docs/source/developer_guides/models.md)
-- [Tasks](docs/source/developer_guides/tasks.md)
-- [Writing Test](tests/README.md)
-- [Writing Documentation](docs/README.md)
+- [How To Guides](https://chanzuckerberg.github.io/cz-benchmarks/how_to_guides/index.html)
+    - [Add a Custom Dataset](https://chanzuckerberg.github.io/cz-benchmarks/how_to_guides/add_custom_dataset.html)
+    - [Add a Custom Model](https://chanzuckerberg.github.io/cz-benchmarks/how_to_guides/add_custom_model.html)
+- [Developer Guides](https://chanzuckerberg.github.io/cz-benchmarks/developer_guides/index.html)
+- [API Reference](https://chanzuckerberg.github.io/cz-benchmarks/api_reference.html)
+- [Assets](https://chanzuckerberg.github.io/cz-benchmarks/assets.html)
 
-### Policies
-- [Assets](docs/source/assets.md)
-- [Governance](docs/source/policy/definitions.md)
-- [Code of Conduct](CODE_OF_CONDUCT.md)
-
-### Additional Resources
-- [Changelog & Release Notes](CHANGELOG.md)
-- [Roadmap](docs/source/roadmap.md)
-- [Legal](LICENSE.md)
-- [Security](SECURITY.md)
+📖 **Documentation**: The full documentation is available at [cz-benchmarks](https://chanzuckerberg.github.io/cz-benchmarks/)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## PROJECT STATUS: UNSTABLE
 
-⚠️ **Warning:** Repository under active development and is in the alpha phase of development, subject to major refactors as outlined in the public-facing [roadmap](docs/source/roadmap.md).
+⚠️ **Warning:** Repository under active development and is in the alpha phase of development, subject to major refactors as outlined in the public-facing [roadmap](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/roadmap.md).
 
 ### What is cz-benchmarks?
 cz-benchmarks is a package for standardized evaluation and comparison of machine learning models for biological applications (first, in the single-cell transcriptomics domain, with future plans to expand to additional domains). The package provides a toolkit for running containerized models, executing biologically-relevant tasks, and computing performance metrics. We see this tool as a step towards ensuring that large-scale AI models can be harnessed to deliver genuine biological insights -- by building trust, accelerating development, and bridging the gap between ML and biology communities.
@@ -17,31 +17,32 @@ We're working to get the alpha version of cz-benchmarks stable to build with the
 ## Table of contents
 
 ### Getting Started
-- [Quick Start Guide](docs/source/quick_start.md)
+- [Quick Start Guide](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/quick_start.md)
 
 ### How-To Guides
-- [Add a Custom Dataset](docs/source/how_to_guides/add_custom_dataset.md)
-- [Add a Custom Model](docs/source/how_to_guides/add_custom_model.md)
-- [Add a New Metric](docs/source/how_to_guides/add_new_metric.md)
-- [Add a New Task](docs/source/how_to_guides/add_new_task.md)
-- [Interactive Mode](docs/source/how_to_guides/interactive_mode.md)
-- [Visualize Results](docs/source/how_to_guides/visualize_results.md)
+- [Add a Custom Dataset](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/how_to_guides/add_custom_dataset.md)
+- [Add a Custom Model](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/how_to_guides/add_custom_model.md)
+- [Add a New Metric](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/how_to_guides/add_new_metric.md)
+- [Add a New Task](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/how_to_guides/add_new_task.md)
+- [Interactive Mode](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/how_to_guides/interactive_mode.md)
+- [Visualize Results](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/how_to_guides/visualize_results.md)
 
 ### Developer Guides
-- [Datasets](docs/source/developer_guides/datasets.md)
-- [Metrics](docs/source/developer_guides/metrics.md)
-- [Models](docs/source/developer_guides/models.md)
-- [Tasks](docs/source/developer_guides/tasks.md)
-- [Writing Test](tests/README.md)
-- [Writing Documentation](docs/README.md)
+- [Datasets](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/developer_guides/datasets.md)
+- [Metrics](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/developer_guides/metrics.md)
+- [Models](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/developer_guides/models.md)
+- [Tasks](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/developer_guides/tasks.md)
+- [Debugging](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/developer_guides/debugging.md)
+- [Writing Test](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/tests/README.md)
+- [Writing Documentation](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/README.md)
 
 ### Policies
-- [Assets](docs/source/assets.md)
-- [Governance](docs/source/policy/definitions.md)
-- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Assets](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/assets.md)
+- [Governance](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/policy/definitions.md)
+- [Code of Conduct](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/CODE_OF_CONDUCT.md)
 
 ### Additional Resources
-- [Changelog & Release Notes](CHANGELOG.md)
-- [Roadmap](docs/source/roadmap.md)
-- [Legal](LICENSE.md)
-- [Security](SECURITY.md)
+- [Changelog & Release Notes](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/CHANGELOG.md)
+- [Roadmap](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/docs/source/roadmap.md)
+- [Legal](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/LICENSE.md)
+- [Security](https://github.com/chanzuckerberg/cz-benchmarks/blob/main/SECURITY.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "cz-benchmarks"
 version = "0.9.0"
 description = "A framework for benchmarking single-cell machine learning models"
 authors = [{ name = "Chan Zuckerberg Initiative", email = "pypi@chanzuckerberg.com" }]
-readme = "README.md"
+readme = "README-pypi.md"
 license = { text = "MIT" }
 requires-python = ">=3.10"
 classifiers = [


### PR DESCRIPTION
Links on pypi are broken as current readme links are relative
- Added a new README for Pypi
- Updated reference in pyproject.toml