### PR TITLE
fix: use macro average for auroc, not weighted (#253)

### DIFF
--- a/src/czbenchmarks/tasks/label_prediction.py
+++ b/src/czbenchmarks/tasks/label_prediction.py
@@ -121,7 +121,7 @@ class MetadataLabelPredictionTask(BaseTask):
             "recall": make_scorer(recall_score, average=target_type),
             "auroc": make_scorer(
                 roc_auc_score,
-                average="weighted",
+                average="macro",
                 multi_class="ovr",
                 response_method="predict_proba",
             ),


### PR DESCRIPTION
This is a pretty straightforward change. I verified the task runs properly with this argument, but I didn't compare the results to the previous setting.