### PR TITLE
chore: expose random seed for nearest_neighbor_hnsw (#255)

### DIFF
--- a/src/czbenchmarks/metrics/utils.py
+++ b/src/czbenchmarks/metrics/utils.py
@@ -1,11 +1,12 @@
-from .types import AggregatedMetricResult, MetricResult
-
 import collections
 import statistics
 from typing import Iterable, Union
 
 import numpy as np
 import pandas as pd
+
+from ..tasks.constants import RANDOM_SEED
+from .types import AggregatedMetricResult, MetricResult
 
 
 def _safelog(a: np.ndarray) -> np.ndarray:
@@ -26,6 +27,7 @@ def nearest_neighbors_hnsw(
     expansion_factor: int = 200,
     max_links: int = 48,
     n_neighbors: int = 100,
+    random_seed: int = RANDOM_SEED,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Find nearest neighbors using HNSW algorithm.
 
@@ -48,6 +50,7 @@ def nearest_neighbors_hnsw(
         max_elements=data.shape[0],
         ef_construction=expansion_factor,
         M=max_links,
+        random_seed=random_seed,
     )
     index.add_items(data, sample_indices)
     index.set_ef(expansion_factor)
@@ -56,7 +59,9 @@ def nearest_neighbors_hnsw(
 
 
 def compute_entropy_per_cell(
-    X: np.ndarray, labels: Union[pd.Categorical, pd.Series, np.ndarray]
+    X: np.ndarray,
+    labels: Union[pd.Categorical, pd.Series, np.ndarray],
+    random_seed: int = RANDOM_SEED,
 ) -> np.ndarray:
     """Compute entropy of batch labels in local neighborhoods.
 
@@ -70,7 +75,7 @@ def compute_entropy_per_cell(
     Returns:
         Array of entropy values for each cell, normalized by log of number of batches
     """
-    indices, _ = nearest_neighbors_hnsw(X, n_neighbors=200)
+    indices, _ = nearest_neighbors_hnsw(X, n_neighbors=200, random_seed=random_seed)
     labels = np.array(list(labels))
     unique_batch_labels = np.unique(labels)
     indices_batch = labels[indices]

--- a/src/czbenchmarks/tasks/integration.py
+++ b/src/czbenchmarks/tasks/integration.py
@@ -84,6 +84,7 @@ class BatchIntegrationTask(BaseTask):
                     entropy_per_cell_metric,
                     X=self.embedding,
                     labels=self.batch_labels,
+                    random_seed=self.random_seed,
                 ),
             ),
             MetricResult(

--- a/src/czbenchmarks/tasks/single_cell/cross_species.py
+++ b/src/czbenchmarks/tasks/single_cell/cross_species.py
@@ -96,6 +96,7 @@ class CrossSpeciesIntegrationTask(BaseTask):
                     entropy_per_cell_metric,
                     X=self.embedding,
                     labels=self.species,
+                    random_seed=self.random_seed,
                 ),
             ),
             MetricResult(


### PR DESCRIPTION
I didn't make it a required argument for the metric, but we could do so instead of having it use the default if the task doesn't supply a random seed. I ran this by hand and verified it's getting plumbed through. 