### PR TITLE
feat: Reapply "geneformer updates" (#266)

### DIFF
--- a/docker/geneformer/config.yaml
+++ b/docker/geneformer/config.yaml
@@ -28,29 +28,11 @@ geneformer_vocabs_uri: s3://cz-benchmarks-data/models/v1/geneformer/vocabs/gene_
 
 # Model configurations
 models:
-  gf_12L_30M:
-    model_name: gf-12L-30M-i2048
-    model_uri: s3://cz-benchmarks-data/models/v1/geneformer/gf-12L-30M-i2048
-    token_config:
-      gene_median_file: gene_dictionaries/gene_median_dictionary_gc30M.pkl
-      token_dictionary_file: gene_dictionaries/token_dictionary_gc30M.pkl
-      ensembl_mapping_file: gene_dictionaries/ensembl_mapping_dict_gc30M.pkl
-      input_size: 2048
-
-  gf_18L_316M:
-    model_name: gf-18L-316M-i4096
-    model_uri: s3://cz-benchmarks-data/models/v1/geneformer/gf-18L-316M-i4096
+  Geneformer-V2-316M:
+    model_name: Geneformer-V2-316M
+    model_uri: s3://cz-benchmarks-data/models/v1/geneformer/Geneformer-V2-316M
     token_config:
       gene_median_file: gene_dictionaries/gene_median_dictionary_gc95M.pkl
       token_dictionary_file: gene_dictionaries/token_dictionary_gc95M.pkl
       ensembl_mapping_file: gene_dictionaries/ensembl_mapping_dict_gc95M.pkl
       input_size: 4096
-
-  gf_6L_30M:
-    model_name: gf-6L-30M-i2048
-    model_uri: s3://cz-benchmarks-data/models/v1/geneformer/gf-6L-30M-i2048
-    token_config:
-      gene_median_file: gene_dictionaries/gene_median_dictionary_gc30M.pkl
-      token_dictionary_file: gene_dictionaries/token_dictionary_gc30M.pkl
-      ensembl_mapping_file: gene_dictionaries/ensembl_mapping_dict_gc30M.pkl
-      input_size: 2048

--- a/docker/geneformer/config.yaml
+++ b/docker/geneformer/config.yaml
@@ -55,6 +55,15 @@ models:
       ensembl_mapping_file: gene_dictionaries/ensembl_mapping_dict_gc95M.pkl
       input_size: 4096
 
+  gf_18L_316M:
+    model_name: gf-18L-316M-i4096
+    model_uri: s3://cz-benchmarks-data/models/v1/geneformer/gf-18L-316M-i4096
+    token_config:
+      gene_median_file: gene_dictionaries/gene_median_dictionary_gc95M.pkl
+      token_dictionary_file: gene_dictionaries/token_dictionary_gc95M.pkl
+      ensembl_mapping_file: gene_dictionaries/ensembl_mapping_dict_gc95M.pkl
+      input_size: 4096
+
   gf_6L_30M:
     model_name: gf-6L-30M-i2048
     model_uri: s3://cz-benchmarks-data/models/v1/geneformer/gf-6L-30M-i2048

--- a/docker/geneformer/config.yaml
+++ b/docker/geneformer/config.yaml
@@ -37,24 +37,6 @@ models:
       ensembl_mapping_file: gene_dictionaries/ensembl_mapping_dict_gc30M.pkl
       input_size: 2048
 
-  gf_12L_95M:
-    model_name: gf-12L-95M-i4096
-    model_uri: s3://cz-benchmarks-data/models/v1/geneformer/gf-12L-95M-i4096
-    token_config:
-      gene_median_file: gene_dictionaries/gene_median_dictionary_gc95M.pkl
-      token_dictionary_file: gene_dictionaries/token_dictionary_gc95M.pkl
-      ensembl_mapping_file: gene_dictionaries/ensembl_mapping_dict_gc95M.pkl
-      input_size: 4096
-
-  gf_20L_95M:
-    model_name: gf-20L-95M-i4096
-    model_uri: s3://cz-benchmarks-data/models/v1/geneformer/gf-20L-95M-i4096
-    token_config:
-      gene_median_file: gene_dictionaries/gene_median_dictionary_gc95M.pkl
-      token_dictionary_file: gene_dictionaries/token_dictionary_gc95M.pkl
-      ensembl_mapping_file: gene_dictionaries/ensembl_mapping_dict_gc95M.pkl
-      input_size: 4096
-
   gf_18L_316M:
     model_name: gf-18L-316M-i4096
     model_uri: s3://cz-benchmarks-data/models/v1/geneformer/gf-18L-316M-i4096

--- a/docker/geneformer/model.py
+++ b/docker/geneformer/model.py
@@ -71,7 +71,7 @@ class Geneformer(GeneformerValidator, BaseModelImplementation):
         parser = argparse.ArgumentParser(
             description="Run Geneformer model on input dataset."
         )
-        parser.add_argument("--model-variant", type=str, default="gf_12L_30M")
+        parser.add_argument("--model_variant", type=str, default="Geneformer-V2-316M")
         return parser
 
     def get_model_weights_subdir(self, _dataset: BaseDataset) -> str:
@@ -218,7 +218,7 @@ class Geneformer(GeneformerValidator, BaseModelImplementation):
             model_type="Pretrained",
             emb_layer=-1,
             emb_mode="cls",
-            forward_batch_size=32,
+            forward_batch_size=16,
             nproc=4,
             token_dictionary_file=str(
                 Path(

--- a/docker/geneformer/model.py
+++ b/docker/geneformer/model.py
@@ -217,7 +217,7 @@ class Geneformer(GeneformerValidator, BaseModelImplementation):
         embex = EmbExtractor(
             model_type="Pretrained",
             emb_layer=-1,
-            emb_mode="cell",
+            emb_mode="cls",
             forward_batch_size=32,
             nproc=4,
             token_dictionary_file=str(

--- a/src/czbenchmarks/conf/models.yaml
+++ b/src/czbenchmarks/conf/models.yaml
@@ -1,5 +1,4 @@
-# TODO: Swap to custom alias for the public ECR registry when it's approved (custom alias: czi-virtual-cells)
-# To view the image sizes, check out the Image Tags in the ECR repository: https://gallery.ecr.aws/y4c8w5f9/cz-benchmarks-models-public
+# To view the image sizes, check out the Image Tags in the ECR repository: https://gallery.ecr.aws/czi-virtual-cells/cz-benchmarks-models-public
 
 # Local Development Example (Using GENEFORMER as an example):
 # 1. Build a local image: `make geneformer`
@@ -7,22 +6,22 @@
 # 3. Update example.py to run inference with GENEFORMER, then run `uv run example.py`
 models:
   SCGPT:
-    model_image_uri: public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:scgpt
+    model_image_uri: public.ecr.aws/czi-virtual-cells/cz-benchmarks-models-public:scgpt
 
   SCVI:
-    model_image_uri: public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:scvi
+    model_image_uri: public.ecr.aws/czi-virtual-cells/cz-benchmarks-models-public:scvi
 
   GENEFORMER:
-    model_image_uri: public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:geneformer
+    model_image_uri: public.ecr.aws/czi-virtual-cells/cz-benchmarks-models-public:geneformer
 
   SCGENEPT:
-    model_image_uri: public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:scgenept
+    model_image_uri: public.ecr.aws/czi-virtual-cells/cz-benchmarks-models-public:scgenept
 
   UCE:
-    model_image_uri: public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:uce
+    model_image_uri: public.ecr.aws/czi-virtual-cells/cz-benchmarks-models-public:uce
 
   AIDO:
-    model_image_uri: public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:aido
+    model_image_uri: public.ecr.aws/czi-virtual-cells/cz-benchmarks-models-public:aido
 
   TRANSCRIPTFORMER:
-    model_image_uri: public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:transcriptformer
+    model_image_uri: public.ecr.aws/czi-virtual-cells/cz-benchmarks-models-public:transcriptformer

--- a/src/czbenchmarks/models/utils.py
+++ b/src/czbenchmarks/models/utils.py
@@ -38,7 +38,8 @@ _MODEL_VARIANT_FINETUNE_TO_DISPLAY = {  # maps a tuple of (name, variant, fine_t
     ("GENEFORMER", "gf_6L_30M", None): ("GENEFORMER", "GF-6L-30M-i2048 (June 2021)"),
     ("GENEFORMER", "gf_12L_30M", None): ("GENEFORMER", "GF-12L-30M-i2048 (June 2021)"),
     ("GENEFORMER", "gf_18L_316M", None): (
-        "GENEFORMER", "Geneformer-V2-316M (May 2025)"
+        "GENEFORMER",
+        "Geneformer-V2-316M (May 2025)",
     ),
     # scGenePT
     (

--- a/src/czbenchmarks/models/utils.py
+++ b/src/czbenchmarks/models/utils.py
@@ -35,9 +35,7 @@ _MODEL_VARIANT_FINETUNE_TO_DISPLAY = {  # maps a tuple of (name, variant, fine_t
     # AIDO
     ("AIDO", "aido_cell_3m", None): ("AIDO", "Cell-3M"),
     # Geneformer
-    ("GENEFORMER", "gf_6L_30M", None): ("GENEFORMER", "GF-6L-30M-i2048 (June 2021)"),
-    ("GENEFORMER", "gf_12L_30M", None): ("GENEFORMER", "GF-12L-30M-i2048 (June 2021)"),
-    ("GENEFORMER", "gf_18L_316M", None): (
+    ("GENEFORMER", "Geneformer-V2-316M", None): (
         "GENEFORMER",
         "Geneformer-V2-316M (May 2025)",
     ),

--- a/src/czbenchmarks/models/utils.py
+++ b/src/czbenchmarks/models/utils.py
@@ -37,8 +37,9 @@ _MODEL_VARIANT_FINETUNE_TO_DISPLAY = {  # maps a tuple of (name, variant, fine_t
     # Geneformer
     ("GENEFORMER", "gf_6L_30M", None): ("GENEFORMER", "GF-6L-30M-i2048 (June 2021)"),
     ("GENEFORMER", "gf_12L_30M", None): ("GENEFORMER", "GF-12L-30M-i2048 (June 2021)"),
-    ("GENEFORMER", "gf_12L_95M", None): ("GENEFORMER", "GF-12L-95M-i4096 (April 2024)"),
-    ("GENEFORMER", "gf_20L_95M", None): ("GENEFORMER", "GF-20L-95M-i4096 (April 2024)"),
+    ("GENEFORMER", "gf_18L_316M", None): (
+        "GENEFORMER", "Geneformer-V2-316M (May 2025)"
+    ),
     # scGenePT
     (
         "SCGENEPT",


### PR DESCRIPTION
Fixes #257
Fixes #234 

* Geneformer updates - `gf_18L_316M` 
* changed AWS public ecr address to the updated path

* Uploaded model weights to: s3://cz-benchmarks-data/models/v1/geneformer/gf-18L-316M-i4096
* changed emb mode from "cell" to "cls"