### PR TITLE
test: 243-automate-model-regression-tests

### DIFF
--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -1,0 +1,60 @@
+name: Model Regression Tests
+
+on:
+  push:
+    branches: [ "*" ]
+    paths:
+      - 'docker/**'
+  pull_request:
+    branches: [ "*" ]
+    paths:
+      - 'docker/**'
+  workflow_dispatch:
+    inputs:
+      model_cases:
+        description: 'Semicolon-separated list of model cases to test (format: model,variant,dataset,task;model,variant,dataset,task;...). Use "all" to run all default cases.'
+        required: true
+        default: 'all'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  model_regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install OpenMP
+        run: sudo apt-get update && sudo apt-get install -y libomp-dev
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv pip install -e ".[dev]"
+
+      - name: Run model regression test
+        run: |
+          source .venv/bin/activate
+          MODEL_CASES_INPUT="${{ github.event.inputs.model_cases }}"
+          if [ "$MODEL_CASES_INPUT" = "all" ] || [ -z "$MODEL_CASES_INPUT" ]; then
+            pytest "tests/models/test_cli_model_regression.py" --run-model-tests
+          else
+            export MODEL_CASES="$MODEL_CASES_INPUT"
+            pytest "tests/models/test_cli_model_regression.py" --run-model-tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,23 +8,8 @@ def pytest_addoption(parser):
         default=0.2,
         help="Percentage tolerance for metric comparison (default: 0.2 = 20%)",
     )
-    parser.addoption(
-        "--run-model-tests",
-        action="store_true",
-        default=False,
-        help="Run model regression tests",
-    )
-
-
-def pytest_configure(config):
-    pytest.run_model_tests = config.getoption("--run-model-tests")
 
 
 @pytest.fixture
 def tolerance_percent(request):
     return request.config.getoption("--tolerance-percent", default=0.2)
-
-
-@pytest.fixture
-def run_model_tests(request):
-    return request.config.getoption("--run-model-tests", default=False)

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -161,7 +161,7 @@ def parse_cases_from_env():
 
 
 def pytest_generate_tests(metafunc):
-    if {
+    if metafunc.function.__name__ == "test_model_regression" and {
         name in metafunc.fixturenames
         for name in ["model_name", "variant", "dataset_name", "task_name"]
     }:

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -126,7 +126,9 @@ def dummy_mouse_dataset(tmp_path):
     dataset.set_input(DataType.METADATA, adata.obs)
     return dataset
 
+
 # region model regression tests
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -159,7 +161,10 @@ def parse_cases_from_env():
 
 
 def pytest_generate_tests(metafunc):
-    if {name in metafunc.fixturenames for name in ["model_name", "variant", "dataset_name", "task_name"]}:
+    if {
+        name in metafunc.fixturenames
+        for name in ["model_name", "variant", "dataset_name", "task_name"]
+    }:
         cases = parse_cases_from_env() or [
             ("SCGPT", "human", "human_spermatogenesis", "clustering"),
             ("SCVI", "homo_sapiens", "human_spermatogenesis", "clustering"),
@@ -170,8 +175,8 @@ def pytest_generate_tests(metafunc):
             ("AIDO", "aido_cell_3m", "human_spermatogenesis", "clustering"),
         ]
         metafunc.parametrize(
-            ("model_name", "variant", "dataset_name", "task_name"),
-            cases
+            ("model_name", "variant", "dataset_name", "task_name"), cases
         )
+
 
 # endregion model regression tests

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -7,6 +7,7 @@ from czbenchmarks.datasets.single_cell import (
 )
 from czbenchmarks.datasets.types import Organism, DataType
 from tests.utils import create_dummy_anndata
+import os
 
 
 @pytest.fixture
@@ -124,3 +125,53 @@ def dummy_mouse_dataset(tmp_path):
     dataset.load_data()
     dataset.set_input(DataType.METADATA, adata.obs)
     return dataset
+
+# region model regression tests
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-model-tests",
+        action="store_true",
+        default=False,
+        help="Run model regression tests",
+    )
+
+
+def pytest_configure(config):
+    pytest.run_model_tests = config.getoption("--run-model-tests")
+
+
+@pytest.fixture
+def run_model_tests(request):
+    return request.config.getoption("--run-model-tests", default=False)
+
+
+def parse_cases_from_env():
+    cases = os.environ.get("MODEL_CASES")
+    if not cases:
+        return None
+    parsed = []
+    for case in cases.split(";"):
+        parts = case.split(",")
+        if len(parts) == 4:
+            parsed.append(tuple(parts))
+    return parsed
+
+
+def pytest_generate_tests(metafunc):
+    if {name in metafunc.fixturenames for name in ["model_name", "variant", "dataset_name", "task_name"]}:
+        cases = parse_cases_from_env() or [
+            ("SCGPT", "human", "human_spermatogenesis", "clustering"),
+            ("SCVI", "homo_sapiens", "human_spermatogenesis", "clustering"),
+            ("GENEFORMER", "gf_6L_30M", "human_spermatogenesis", "clustering"),
+            ("SCGENEPT", "scgpt", "adamson_perturb", "perturbation"),
+            ("UCE", "4l", "human_spermatogenesis", "clustering"),
+            ("TRANSCRIPTFORMER", "tf-sapiens", "tsv2_bladder", "clustering"),
+            ("AIDO", "aido_cell_3m", "human_spermatogenesis", "clustering"),
+        ]
+        metafunc.parametrize(
+            ("model_name", "variant", "dataset_name", "task_name"),
+            cases
+        )
+
+# endregion model regression tests

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -148,7 +148,7 @@ def run_model_tests(request):
     return request.config.getoption("--run-model-tests", default=False)
 
 
-def parse_cases_from_env():
+def parse_model_cases_from_env():
     cases = os.environ.get("MODEL_CASES")
     if not cases:
         return None
@@ -160,12 +160,12 @@ def parse_cases_from_env():
     return parsed
 
 
-def pytest_generate_tests(metafunc):
+def generate_model_cases(metafunc):
     if metafunc.function.__name__ == "test_model_regression" and {
         name in metafunc.fixturenames
         for name in ["model_name", "variant", "dataset_name", "task_name"]
     }:
-        cases = parse_cases_from_env() or [
+        cases = parse_model_cases_from_env() or [
             ("SCGPT", "human", "human_spermatogenesis", "clustering"),
             ("SCVI", "homo_sapiens", "human_spermatogenesis", "clustering"),
             ("GENEFORMER", "gf_6L_30M", "human_spermatogenesis", "clustering"),
@@ -180,3 +180,8 @@ def pytest_generate_tests(metafunc):
 
 
 # endregion model regression tests
+
+
+def pytest_generate_tests(metafunc):
+    if metafunc.function.__name__ == "test_model_regression":
+        generate_model_cases(metafunc)

--- a/tests/models/test_cli_model_regression.py
+++ b/tests/models/test_cli_model_regression.py
@@ -16,27 +16,10 @@ from czbenchmarks.models.types import ModelType
 from czbenchmarks.datasets.types import DataType
 from czbenchmarks.runner import run_inference
 
-MODEL_VARIANT_DATASET_TASK_TEST_CASES = [
-    ("SCGPT", "human", "human_spermatogenesis", "clustering"),
-    ("SCVI", "homo_sapiens", "human_spermatogenesis", "clustering"),
-    ("GENEFORMER", "gf_6L_30M", "human_spermatogenesis", "clustering"),
-    ("SCGENEPT", "scgpt", "adamson_perturb", "perturbation"),
-    ("UCE", "4l", "human_spermatogenesis", "clustering"),
-    ("TRANSCRIPTFORMER", "tf-sapiens", "tsv2_bladder", "clustering"),
-    ("AIDO", "aido_cell_3m", "human_spermatogenesis", "clustering"),
-]
-
 
 @pytest.mark.skipif(
     not pytest.run_model_tests,
     reason="Model regression tests skipped. Use --run-model-tests to run them.",
-)
-@pytest.mark.parametrize(
-    "model_name,variant,dataset_name,task_name",
-    [
-        (model, variant, dataset, task)
-        for model, variant, dataset, task in MODEL_VARIANT_DATASET_TASK_TEST_CASES
-    ],
 )
 def test_model_regression(
     model_name, variant, dataset_name, task_name, tolerance_percent

--- a/tests/models/test_cli_model_regression.py
+++ b/tests/models/test_cli_model_regression.py
@@ -43,14 +43,14 @@ def test_model_regression(
     Environment variables:
     MODEL_CASES: Optional semicolon-separated list of test cases to run.
                  Each test case should be in the format: model,variant,dataset,task
-                 
+
                  Example:
                  SCGPT,human,human_spermatogenesis,clustering;SCVI,homo_sapiens,human_spermatogenesis,clustering
-                 
+
                  If not set, runs all default test cases.
 
     Alternative: You can also run a specific test from the default cases using pytest's node selection syntax:
-                 
+
                  Example:
                  pytest "tests/models/test_cli_model_regression.py::test_model_regression[SCGPT-human-human_spermatogenesis-clustering]" --run-model-tests
     """

--- a/tests/models/test_cli_model_regression.py
+++ b/tests/models/test_cli_model_regression.py
@@ -39,6 +39,20 @@ def test_model_regression(
     Command line arguments:
     --run-model-tests: Required flag to run these tests (skipped by default)
     --tolerance-percent: Optional float (default: 0.2) for metric comparison tolerance
+
+    Environment variables:
+    MODEL_CASES: Optional semicolon-separated list of test cases to run.
+                 Each test case should be in the format: model,variant,dataset,task
+                 
+                 Example:
+                 SCGPT,human,human_spermatogenesis,clustering;SCVI,homo_sapiens,human_spermatogenesis,clustering
+                 
+                 If not set, runs all default test cases.
+
+    Alternative: You can also run a specific test from the default cases using pytest's node selection syntax:
+                 
+                 Example:
+                 pytest "tests/models/test_cli_model_regression.py::test_model_regression[SCGPT-human-human_spermatogenesis-clustering]" --run-model-tests
     """
     # region Setup
     dataset = load_dataset(dataset_name)


### PR DESCRIPTION
## Automate model regression tests #243

### Changes
- Added GitHub Actions workflow to run model regression tests
- runs on
  - Push to any branch when `/docker` directory changes
  - Pull requests to any branch when `/docker` directory changes
  - Manual trigger via workflow dispatch with configurable test cases

### Test Case Selection
Added `MODEL_CASES` env to run specific test cases:
Environment variable:
   ```bash
   MODEL_CASES="SCGPT,human,human_spermatogenesis,clustering" pytest tests/models/test_cli_model_regression.py --run-model-tests
   ```