### PR TITLE
PR: Add non_control_mean baseline to set_baseline() for perturbation prediction

### DIFF
--- a/pr_baseline_fix_test.py
+++ b/pr_baseline_fix_test.py
@@ -1,0 +1,50 @@
+from czbenchmarks.datasets.utils import load_dataset
+from czbenchmarks.runner import run_inference
+from czbenchmarks.tasks import PerturbationTask
+from czbenchmarks.models.types import ModelType
+from czbenchmarks.datasets.types import DataType
+import pandas as pd
+import numpy as np
+
+# === Config
+RAW_DATASET_NAME = "norman_perturb"
+MODEL_NAME = "SCGENEPT"
+MODEL_KEY = "norman"
+MODEL_VARIANT = "scgenept_ncbi+uniprot_gpt"
+PERTURBATION = "POU3F2+ctrl"
+
+# === Load and hydrate dataset
+print("🧠 Loading and re-hydrating dataset...")
+dataset = load_dataset(RAW_DATASET_NAME)
+dataset = run_inference(
+    MODEL_NAME,
+    dataset=dataset,
+    gene_pert=PERTURBATION,
+    dataset_name=MODEL_KEY,
+    model_variant=MODEL_VARIANT,
+    use_gears=True,
+)
+
+# === Test baseline types
+try:
+    adata = dataset.get_input(DataType.ANNDATA)
+except KeyError:
+    raise RuntimeError("❌ Could not find ANNDATA in dataset. Aborting.")
+
+def run_and_eval(baseline_type: str):
+    print(f"\n🔬 Running baseline_type='{baseline_type}'")
+    task = PerturbationTask()
+    try:
+        task.set_baseline(dataset, gene_pert=PERTURBATION, baseline_type=baseline_type)
+        results = task.run(dataset)
+        print(f"✅ Completed baseline_type='{baseline_type}'")
+    except Exception as e:
+        print(f"❌ Failed baseline_type='{baseline_type}': {e}")
+        return
+
+    for r in results["BASELINE"]:
+        print(f"{r.metric_type.value:25s} | subset: {r.params['subset']:7s} | value: {r.value:.5f}")
+
+# === Run all 3 baselines with metrics ===
+for btype in ["median", "mean", "non_control_mean"]:
+    run_and_eval(btype)


### PR DESCRIPTION
This PR extends the PerturbationTask.set_baseline() method to include a new baseline strategy:

+ baseline_type="non_control_mean"
Implements the "Non-control-mean" strategy described in the [scGenePT](https://www.biorxiv.org/content/10.1101/2024.10.23.619972v1) paper:

"Non-control-mean Following Martens et al. [[23](https://www.biorxiv.org/content/10.1101/2024.10.23.619972v1.full#ref-23)] who found the non-control mean to be a strong baseline, we add this as a baseline in our analyses as well. In this setting, we take an average of all the perturbation responses from training data, and make that prediction for all the perturbations in the testing data."

This is now implemented by:

Identifying non-control cells (default column = "condition_name", with fallbacks to "perturbation" or "group")

Averaging across their expression vectors

Tiling the mean vector to match the full dataset

Storing the result as a baseline prediction in data.set_output(...)

✅ Also included:
A validation test (pr_baseline_fix_test.py) comparing:

"median" (original)

"mean" (original)

"non_control_mean" (new)

The test uses real data (norman_perturb) and prints comparative metrics for verification