### PR TITLE
Patch/scgenept consistent data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ scgpt:
 scgenept:
 	docker build -t cz-benchmarks-models:scgenept -f docker/scgenept/Dockerfile .
 
+.PHONY: scgenept-patched
+scgenept-patched:
+	docker build -t cz-benchmarks-models:scgenept_patched -f docker/scgenept/Dockerfile.patch .
+	
 # Build the geneformer image
 .PHONY: geneformer
 geneformer:

--- a/docker/scgenept/Dockerfile.patch
+++ b/docker/scgenept/Dockerfile.patch
@@ -1,0 +1,4 @@
+FROM public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:scgenept
+
+# overwrite the dataset loader inside the image
+COPY src/czbenchmarks/datasets/single_cell.py /app/package/src/czbenchmarks/datasets/single_cell.py

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -25,7 +25,7 @@ pip install cz-benchmarks
 
 ### Option 2: Install from Source (For Development)
 
-If you plan to contribute or debug the library, install it from source:
+If you plan to contribute or dpleaseebug the library, install it from source:
 
 1. Clone the repository:
 
@@ -44,6 +44,29 @@ If you plan to contribute or debug the library, install it from source:
 
     ```bash
     pip install -e ".[dev]"
+    ```
+
+## Building and using the Patched cz-benchmarks SCGENEPT Image
+1. From the root of your repo, run:
+
+   ```bash
+   make scgenept-patched
+   ```
+
+2.	Verify the image was built:
+
+    ```
+    docker images | grep scgenept_patched
+    ```
+
+3.	Point the CZ-Benchmarks runner at your patched image by using the custom models config:
+    ```    
+    dataset = run_inference(
+        "SCGENEPT",
+        ...        
+        custom_config_path="conf/models-patched.yaml",
+        ...
+        )
     ```
 
 ## Running Benchmarks

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -46,7 +46,7 @@ If you plan to contribute or dpleaseebug the library, install it from source:
     pip install -e ".[dev]"
     ```
 
-## Building and using the Patched cz-benchmarks SCGENEPT Image
+## Building and using the Patched cz-benchmarks SCGENEPT Image for Performance Evaluation
 1. From the root of your repo, run:
 
    ```bash

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -25,7 +25,7 @@ pip install cz-benchmarks
 
 ### Option 2: Install from Source (For Development)
 
-If you plan to contribute or dpleaseebug the library, install it from source:
+If you plan to contribute or debug the library, install it from source:
 
 1. Clone the repository:
 

--- a/src/czbenchmarks/conf/models-patched.yaml
+++ b/src/czbenchmarks/conf/models-patched.yaml
@@ -1,0 +1,28 @@
+# TODO: Swap to custom alias for the public ECR registry when it's approved (custom alias: czi-virtual-cells)
+# To view the image sizes, check out the Image Tags in the ECR repository: https://gallery.ecr.aws/y4c8w5f9/cz-benchmarks-models-public
+
+# Local Development Example (Using GENEFORMER as an example):
+# 1. Build a local image: `make geneformer`
+# 2. Update geneformer model_image_uri: cz-benchmarks-models:geneformer
+# 3. Update example.py to run inference with GENEFORMER, then run `uv run example.py`
+models:
+  SCGPT:
+    model_image_uri: public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:scgpt
+
+  SCVI:
+    model_image_uri: public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:scvi
+
+  GENEFORMER:
+    model_image_uri: public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:geneformer
+
+  SCGENEPT:
+    model_image_uri: cz-benchmarks-models:scgenept_patched
+
+  UCE:
+    model_image_uri: public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:uce
+
+  AIDO:
+    model_image_uri: public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:aido
+
+  TRANSCRIPTFORMER:
+    model_image_uri: public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:transcriptformer

--- a/src/czbenchmarks/datasets/single_cell.py
+++ b/src/czbenchmarks/datasets/single_cell.py
@@ -134,10 +134,10 @@ class PerturbationSingleCellDataset(SingleCellDataset):
             truth_data,
         )
 
-        self.set_input(
-            DataType.ANNDATA,
-            self.adata[self.adata.obs[self.condition_key] == "ctrl"].copy(),
-        )
+        # self.set_input(
+        #     DataType.ANNDATA,
+        #     self.adata[self.adata.obs[self.condition_key] == "ctrl"].copy(),
+        # )
 
     def unload_data(self) -> None:
         super().unload_data()


### PR DESCRIPTION
During Eval, we need ground- truth pert values to be compared with our prediction data. Thus predicting on ctrl data is not valid since there is no  ground- truth pert values. single_cell.py is modified to accommodate that change. Also these changes should be also mirrored in the public.ecr.aws/y4c8w5f9/cz-benchmarks-models-public:scgenept image. This is done be creating a new image with that change and modifying the models.yalm accordingly.

Changes:
src/czbenchmarks/datasets/single_cell.py : remove loading only the ctrl set
docker/scgenept/Dockerfile.patch : Dockerfile to pull from public and copy the modified single_cell.py in it
Makefile: add directives for building the the modified image
src/czbenchmarks/conf/models-patched.yaml: configuration to use the new modified image.

