### PR TITLE
fix: fix UCE docker image build by switching to miniforge due to conda TOS changes

### DIFF
--- a/docker/uce/Dockerfile
+++ b/docker/uce/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get update && apt-get install -y \
 
 # Install Miniconda
 # TODO: remove conda as it does not appear to be needed
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && \
-    bash miniconda.sh -b -p /opt/conda && \
-    rm miniconda.sh
+RUN wget -O miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh" && \
+    bash miniforge3.sh -b -p /opt/conda && \
+    rm miniforge3.sh
 
 # Add conda to path and create Python 3.11 environment
 ENV PATH="/opt/conda/bin:${PATH}"


### PR DESCRIPTION
We were seeing "[CondaToSNonInteractiveError](https://stackoverflow.com/questions/79702788/condatosnoninteractiveerror-terms-of-service-have-not-been-accepted)"s in the build, due to anaconda's [recent TOS changes](https://www.anaconda.com/legal/terms/terms-of-service).

This fixes it for me, locally at least.