### PR TITLE
DRAFT: Updates to single cell perturbation datasets and related classes for new perturb seq task

### DIFF
--- a/src/czbenchmarks/conf/datasets.yaml
+++ b/src/czbenchmarks/conf/datasets.yaml
@@ -2,40 +2,11 @@ defaults:
   - _self_
 
 datasets:
-  adamson_perturb:
+  replogle_k562_essential_perturb:
     _target_: czbenchmarks.datasets.PerturbationSingleCellLabeledDataset
     organism: ${organism:HUMAN}
     condition_key: condition
-    split_key: split
-    path: s3://cz-benchmarks-data/datasets/v1/perturb/single_cell/adamson_perturbation.h5ad
-
-  norman_perturb:
-    _target_: czbenchmarks.datasets.PerturbationSingleCellLabeledDataset
-    organism: ${organism:HUMAN}
-    condition_key: condition
-    split_key: split
-    path: s3://cz-benchmarks-data/datasets/v1/perturb/single_cell/norman_perturbation.h5ad
-
-  dixit_perturb:
-    _target_: czbenchmarks.datasets.PerturbationSingleCellLabeledDataset
-    organism: ${organism:HUMAN}
-    condition_key: condition
-    split_key: split
-    path: s3://cz-benchmarks-data/datasets/v1/perturb/single_cell/dixit_perturbation.h5ad
-
-  replogle_k562_perturb:
-    _target_: czbenchmarks.datasets.PerturbationSingleCellLabeledDataset
-    organism: ${organism:HUMAN}
-    condition_key: condition
-    split_key: split
     path: s3://cz-benchmarks-data/datasets/v1/perturb/single_cell/replogle_k562_essential_perturbation.h5ad
-
-  replogle_rpe1_perturb:
-    _target_: czbenchmarks.datasets.PerturbationSingleCellLabeledDataset
-    organism: ${organism:HUMAN}
-    condition_key: condition
-    split_key: split
-    path: s3://cz-benchmarks-data/datasets/v1/perturb/single_cell/replogle_rpe1_essential_perturbation.h5ad
 
   human_spermatogenesis:
     _target_: czbenchmarks.datasets.SingleCellLabeledDataset

--- a/src/czbenchmarks/datasets/single_cell_perturbation.py
+++ b/src/czbenchmarks/datasets/single_cell_perturbation.py
@@ -37,7 +37,6 @@ class SingleCellPerturbationDataset(SingleCellDataset):
         path: Path,
         organism: Organism,
         condition_key: str = "condition",
-        split_key: str = "split",
         task_inputs_dir: Optional[Path] = None,
     ):
         """
@@ -48,24 +47,21 @@ class SingleCellPerturbationDataset(SingleCellDataset):
             organism (Organism): Enum value indicating the organism.
             condition_key (str): Key for the column in `adata.obs` specifying conditions.
                 Defaults to "condition".
-            split_key (str): Key for the column in `adata.obs` specifying splits.
-                Defaults to "split".
             task_inputs_dir (Optional[Path]): Directory for storing task-specific inputs.
         """
         super().__init__("single_cell_perturbation", path, organism, task_inputs_dir)
         self.condition_key = condition_key
-        self.split_key = split_key
 
     def load_data(self) -> None:
         """
         Load the dataset and populate perturbation truth data.
 
-        This method validates the presence of `condition_key` and `split_key` in
+        This method validates the presence of `condition_key` in
         `adata.obs`, and extracts control data for each condition into the
         `perturbation_truth` attribute.
 
         Raises:
-            ValueError: If `condition_key` or `split_key` is not found in `adata.obs`.
+            ValueError: If `condition_key` not found in `adata.obs`.
         """
         super().load_data()
 
@@ -119,23 +115,15 @@ class SingleCellPerturbationDataset(SingleCellDataset):
         Perform dataset-specific validation.
 
         Validates the following:
-        - Split values must be one of {"train", "test", "val"}.
         - Condition format must be one of:
           - ``ctrl`` for control samples.
-          - ``{gene}+ctrl`` for single gene perturbations.
-          - ``{gene1}+{gene2}`` for combinatorial perturbations.
+          - ``{perturb}+ctrl`` for single perturbation.
+          - ``{perturb1}+{perturb2}`` for combinatorial perturbations.
 
         Raises:
-            ValueError: If invalid split values or condition formats are found.
+            ValueError: If invalid condition formats are found.
         """
         super()._validate()
-
-        # Validate split values
-        valid_splits = {"train", "test", "val"}
-        splits = set(self.adata.obs[self.split_key])
-        invalid_splits = splits - valid_splits
-        if invalid_splits:
-            raise ValueError(f"Invalid split value(s): {invalid_splits}")
 
         # Validate condition format
         conditions = (
@@ -150,5 +138,5 @@ class SingleCellPerturbationDataset(SingleCellDataset):
             if len(parts) != 2:
                 raise ValueError(
                     f"Invalid perturbation condition format: {condition}. "
-                    "Must be 'ctrl', '{gene}+ctrl', or '{gene1}+{gene2}'"
+                    "Must be 'ctrl', '{perturb}+ctrl', or '{perturb1}+{perturb2}'"
                 )


### PR DESCRIPTION
Required updates to update Replogle K562 essentials for the new perturb seq task:

* Removes the split key as this is not required for zero-shot tasks
* Removes other single cell perturbation datasets for now since they will need to be reformatted and tested to ensure support with new class

closes #352 
closes #350 