### PR TITLE
fix: for publish-pypi to work on prod pypi

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Display version being published
         run: |
-          echo "Publishing version: ${{ steps.get_version.outputs.VERSION }}"
+          echo "Publishing version: ${{ steps.get_version.outputs.VERSION }} from ${{ github.ref }}"
 
       - name: Install dependencies
         run: uv sync --group build

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Display version being published
         run: |
-          echo "Publishing version: ${{ steps.get_version.outputs.VERSION }} from ${{ github.ref }}"
+          echo "Publishing version: ${{ steps.get_version.outputs.VERSION }} from ${{ github.ref }} for event ${{ github.event_name }}"
 
       - name: Install dependencies
         run: uv sync --group build
@@ -89,7 +89,7 @@ jobs:
 
       - name: Display version being published
         run: |
-          echo "Publishing version: ${{ steps.get_version.outputs.VERSION }}"
+          echo "Publishing version: ${{ steps.get_version.outputs.VERSION }} from ${{ github.ref }} for event ${{ github.event_name }}"
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -71,7 +71,7 @@ jobs:
     # This job will only run if the test-pypi job is successful
     needs: publish-test-pypi
     # Only run if done for an official release, not via a triggered workflow, which is used for testing
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment:
       name: pypi


### PR DESCRIPTION
I'm not sure how the `if` condition ever worked previously, but it clearly did (it's been a while since we've done a prod release, so likely not remembering this history).

