### PR TITLE
docs: Improve autoapi generated documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,7 @@ autoapi_dirs = ["../../src/"]
 autoapi_type = "python"
 autoapi_add_toctree_entry = False
 autoapi_keep_files = True
-
+autoapi_python_class_content = 'both' 
 
 napoleon_google_docstring = True
 napoleon_numpy_docstring = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,7 @@ autoapi_dirs = ["../../src/"]
 autoapi_type = "python"
 autoapi_add_toctree_entry = False
 autoapi_keep_files = True
-autoapi_python_class_content = 'both' 
+autoapi_python_class_content = "both"
 
 napoleon_google_docstring = True
 napoleon_numpy_docstring = True


### PR DESCRIPTION
The online documentation only shows the base class information for classes, e.g.  [here](https://chanzuckerberg.github.io/cz-benchmarks/autoapi/czbenchmarks/tasks/single_cell/index.html#czbenchmarks.tasks.single_cell.PerturbationExpressionPredictionTask). The acutal class docstrings would be more helpful to users. 

This msall configuration change will include the `__init__` docstrings of the relevant (child) class, albeit with the trade off of having both. I am unable find a way to show only the docstrings for the child class.
