### PR TITLE
docs: Update colors to match other sites in VCP ecosystem

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,3 +1,10 @@
+html, body {
+    --sd-color-primary: #6E4FF9;
+    --sd-color-primary-highlight: #6E4FF9;
+    --sd-color-secondary: #EFEAFE;
+    --sd-color-secondary-dark: #331252;
+}
+
 body, .diagram-font {
     font-family: Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
       Helvetica Neue, Helvetica, Arial, sans-serif;
@@ -12,155 +19,178 @@ body, .diagram-font {
     font-family: Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
       Helvetica Neue, Helvetica, Arial, sans-serif;
   }
-  
-  .wy-side-nav-search {
-    background-color: #6f67ff;
-  }
-  
-  .wy-nav-side {
-    background: #0e1214;
-  }
-  
-  .wy-menu-vertical a {
-    color: #96a7b5;
-  }
-  
-  .wy-menu-vertical a:hover {
-    color: white;
-  }
-  
-  .wy-nav-content-wrap {
+
+.wy-side-nav-search {
+  background-color: #6f67ff;
+}
+
+.wy-nav-side {
+  background: #0e1214;
+}
+
+.wy-menu-vertical a {
+  color: white;
+}
+
+.wy-menu-vertical a:hover {
+  color: white;
+}
+
+.wy-menu-vertical header, .wy-menu-vertical p.caption {
+  color: white;
+}
+
+.wy-menu-vertical a:active {
+    background-color: #4e4a4a;
+    cursor: pointer;
+    color: #fff;
+}
+
+.wy-nav-content-wrap {
+  background: white;
+}
+
+.wy-nav-content {
+  max-width: 1200px;
+  background: white;
+}
+
+.wy-nav-content-wrap {
     background: white;
-  }
-  
-  .wy-nav-content {
+}
+
+.wy-nav-content {
     max-width: 1200px;
     background: white;
-  }
+}
+
+.rst-content a:visited {
+    color: var(--sd-color-primary);
+}
+
+.rst-content a:hover {
+    color: var(--sd-color-secondary-dark);
+}
+
+/* Custom colors */
   
-  /* Custom colors */
-  
-  .rst-content .admonition,
-  .rst-content .admonition-todo,
-  .rst-content .attention,
-  .rst-content .caution,
-  .rst-content .danger,
-  .rst-content .error,
-  .rst-content .hint,
-  .rst-content .important,
-  .rst-content .note,
-  .rst-content .seealso,
-  .rst-content .tip,
-  .rst-content .warning,
-  .wy-alert {
-    padding: 12px;
-    line-height: 24px;
-    margin-bottom: 24px;
-    background: #e0f0ff;
-  }
-  
-  .rst-content .note,
-  .rst-content .seealso,
-  .rst-content .wy-alert-info.admonition,
-  .rst-content .wy-alert-info.admonition-todo,
-  .rst-content .wy-alert-info.attention,
-  .rst-content .wy-alert-info.caution,
-  .rst-content .wy-alert-info.danger,
-  .rst-content .wy-alert-info.error,
-  .rst-content .wy-alert-info.hint,
-  .rst-content .wy-alert-info.important,
-  .rst-content .wy-alert-info.tip,
-  .rst-content .wy-alert-info.warning,
-  .wy-alert.wy-alert-info {
-    background: #e0f0ff;
-  }
-  
-  html.writer-html4 .rst-content dl:not(.docutils) > dt,
-  html.writer-html5
-    .rst-content
-    dl[class]:not(.option-list):not(.field-list):not(.footnote):not(
-      .citation
-    ):not(.glossary):not(.simple)
-    > dt {
-    display: table;
-    margin: 6px 0;
-    font-size: 90%;
-    line-height: normal;
-    background: #e0f0ff;
-    color: #0073ff;
-    border-top: 3px solid #8cc3ff;
-    padding: 6px;
-    position: relative;
-  }
-  
-  .rst-content .guilabel {
-    border: 1px solid #7fbbe3;
-    background: #e0f0ff;
-    font-size: 80%;
-    font-weight: 700;
-    border-radius: 4px;
-    padding: 2.4px 6px;
-    margin: auto 2px;
-  }
-  
-  .rst-content .wy-alert-neutral.admonition-todo a,
-  .rst-content .wy-alert-neutral.admonition a,
-  .rst-content .wy-alert-neutral.attention a,
-  .rst-content .wy-alert-neutral.caution a,
-  .rst-content .wy-alert-neutral.danger a,
-  .rst-content .wy-alert-neutral.error a,
-  .rst-content .wy-alert-neutral.hint a,
-  .rst-content .wy-alert-neutral.important a,
-  .rst-content .wy-alert-neutral.note a,
-  .rst-content .wy-alert-neutral.seealso a,
-  .rst-content .wy-alert-neutral.tip a,
-  .rst-content .wy-alert-neutral.warning a,
-  .wy-alert.wy-alert-neutral a {
-    color: #0073ff;
-  }
-  .wy-tray-container li.wy-tray-item-info {
-    background: #0073ff;
-  }
-  .btn-info {
-    background-color: #0073ff !important;
-  }
-  .btn-link {
-    background-color: transparent !important;
-    color: #0073ff;
-    box-shadow: none;
-    border-color: transparent !important;
-  }
-  .wy-dropdown-menu > dd > a:hover {
-    background: #0073ff;
-    color: #fff;
-  }
-  .wy-dropdown.wy-dropdown-bubble .wy-dropdown-menu a:hover {
-    background: #0073ff;
-    color: #fff;
-  }
-  .wy-inline-validate.wy-inline-validate-info .wy-input-context {
-    color: #0073ff;
-  }
-  a {
-    color: #0073ff;
-    text-decoration: none;
-    cursor: pointer;
-  }
-  .wy-text-info {
-    color: #0073ff !important;
-  }
-  .wy-menu-vertical a:active {
-    background-color: #0073ff;
-    cursor: pointer;
-    color: #fff;
-  }
+.rst-content .admonition,
+.rst-content .admonition-todo,
+.rst-content .attention,
+.rst-content .caution,
+.rst-content .danger,
+.rst-content .error,
+.rst-content .hint,
+.rst-content .important,
+.rst-content .note,
+.rst-content .seealso,
+.rst-content .tip,
+.rst-content .warning,
+.wy-alert {
+  padding: 12px;
+  line-height: 24px;
+  margin-bottom: 24px;
+  background: #e0f0ff;
+}
+
+.rst-content .note,
+.rst-content .seealso,
+.rst-content .wy-alert-info.admonition,
+.rst-content .wy-alert-info.admonition-todo,
+.rst-content .wy-alert-info.attention,
+.rst-content .wy-alert-info.caution,
+.rst-content .wy-alert-info.danger,
+.rst-content .wy-alert-info.error,
+.rst-content .wy-alert-info.hint,
+.rst-content .wy-alert-info.important,
+.rst-content .wy-alert-info.tip,
+.rst-content .wy-alert-info.warning,
+.wy-alert.wy-alert-info {
+  background: #e0f0ff;
+}
+
+html.writer-html4 .rst-content dl:not(.docutils) > dt,
+html.writer-html5
+  .rst-content
+  dl[class]:not(.option-list):not(.field-list):not(.footnote):not(
+    .citation
+  ):not(.glossary):not(.simple)
+  > dt {
+  display: table;
+  margin: 6px 0;
+  font-size: 90%;
+  line-height: normal;
+  background: var(--sd-color-secondary);
+  color: var(--sd-color-primary);
+  border-top: 3px solid var(--sd-color-primary-highlight);
+  padding: 6px;
+  position: relative;
+}
+
+.rst-content .guilabel {
+  border: 1px solid var(--sd-color-secondary-dark);
+  background: var(--sd-color-secondary);
+  font-size: 80%;
+  font-weight: 700;
+  border-radius: 4px;
+  padding: 2.4px 6px;
+  margin: auto 2px;
+}
+
+.rst-content .wy-alert-neutral.admonition-todo a,
+.rst-content .wy-alert-neutral.admonition a,
+.rst-content .wy-alert-neutral.attention a,
+.rst-content .wy-alert-neutral.caution a,
+.rst-content .wy-alert-neutral.danger a,
+.rst-content .wy-alert-neutral.error a,
+.rst-content .wy-alert-neutral.hint a,
+.rst-content .wy-alert-neutral.important a,
+.rst-content .wy-alert-neutral.note a,
+.rst-content .wy-alert-neutral.seealso a,
+.rst-content .wy-alert-neutral.tip a,
+.rst-content .wy-alert-neutral.warning a,
+.wy-alert.wy-alert-neutral a {
+  color: var(--sd-color-primary);
+}
+.wy-tray-container li.wy-tray-item-info {
+  background: var(--sd-color-primary);
+}
+.btn-info {
+  background-color: var(--sd-color-primary) !important;
+}
+.btn-link {
+  background-color: transparent !important;
+  color: var(--sd-color-primary);
+  box-shadow: none;
+  border-color: transparent !important;
+}
+.wy-dropdown-menu > dd > a:hover {
+  background: var(--sd-color-primary);
+  color: #fff;
+}
+.wy-dropdown.wy-dropdown-bubble .wy-dropdown-menu a:hover {
+  background: var(--sd-color-primary);
+  color: #fff;
+}
+.wy-inline-validate.wy-inline-validate-info .wy-input-context {
+  color: var(--sd-color-primary);
+}
+a {
+  color: var(--sd-color-primary);
+  text-decoration: none;
+  cursor: pointer;
+}
+.wy-text-info {
+  color: var(--sd-color-primary) !important;
+}
+
   .wy-side-nav-search {
     display: block;
     width: 300px;
     padding: 0.809em;
     margin-bottom: 0.809em;
     z-index: 200;
-    background-color: #0073ff;
+    background-color: var(--sd-color-primary);
     text-align: center;
     color: #fcfcfc;
   }
@@ -169,20 +199,20 @@ body, .diagram-font {
     margin: auto auto 0.809em;
     height: 45px;
     width: 45px;
-    background-color: #0073ff;
+    background-color: var(--sd-color-primary);
     padding: 5px;
     border-radius: 100%;
   }
   .wy-nav .wy-menu-vertical header {
-    color: #0073ff;
+    color: var(--sd-color-primary);
   }
   .wy-nav .wy-menu-vertical a:hover {
-    background-color: #0073ff;
+    background-color: var(--sd-color-primary);
     color: #fff;
   }
   .wy-nav-top {
     display: none;
-    background: #0073ff;
+    background: var(--sd-color-primary);
     color: #fff;
     padding: 0.4045em 0.809em;
     position: relative;
@@ -195,17 +225,17 @@ body, .diagram-font {
     margin-right: 12px;
     height: 45px;
     width: 45px;
-    background-color: #0073ff;
+    background-color: var(--sd-color-primary);
     padding: 5px;
     border-radius: 100%;
   }
   .rst-versions a {
-    color: #0073ff;
+    color: var(--sd-color-primary);
     text-decoration: none;
   }
   .rst-content a code,
   .rst-content a tt {
-    color: #0073ff;
+    color: var(--sd-color-primary);
   }
   html.writer-html4 .rst-content dl:not(.docutils) > dt,
   html.writer-html5
@@ -218,9 +248,9 @@ body, .diagram-font {
     margin: 6px 0;
     font-size: 90%;
     line-height: normal;
-    background: #e7f2fa;
-    color: #0073ff;
-    border-top: 3px solid #8cc3ff;
+    background: var(--sd-color-secondary);
+    color: var(--sd-color-primary);
+    border-top: 3px solid var(--sd-color-secondary-dark);
     padding: 6px;
     position: relative;
   }
@@ -230,7 +260,7 @@ body, .diagram-font {
     font-weight: 700;
     display: block;
     color: #fff;
-    background: #8cc3ff;
+    background: var(--sd-color-secondary);
     padding: 6px 12px;
     margin: -12px -12px 12px;
   }
@@ -261,7 +291,7 @@ body, .diagram-font {
   .rst-content .wy-alert.wy-alert-info .admonition-title,
   .wy-alert.wy-alert-info .rst-content .admonition-title,
   .wy-alert.wy-alert-info .wy-alert-title {
-    background: #8cc3ff;
+    background: var(--sd-color-secondary);
   }
   html.writer-html4 .rst-content dl:not(.docutils) > dt,
   html.writer-html5
@@ -274,9 +304,9 @@ body, .diagram-font {
     margin: 6px 0;
     font-size: 90%;
     line-height: normal;
-    background: #e7f2fa;
-    color: #0073ff;
-    border-top: 3px solid #8cc3ff;
+    background: var(--sd-color-secondary);
+    color: var(--sd-color-primary);
+    border-top: 3px solid var(--sd-color-secondary-dark);
     padding: 6px;
     position: relative;
   }
@@ -287,12 +317,12 @@ body, .diagram-font {
       .citation
     ):not(.glossary):not(.simple)
     > dt:before {
-    color: #8cc3ff;
+    color: var(--sd-color-secondary);
   }
   
   
   .hs-button {
-    background-color: rgb(143, 90, 255);
+    background-color: var(--sd-color-primary);
     padding: 6px 12px;
     width: fit-content;
     height: 34px;
@@ -303,7 +333,7 @@ body, .diagram-font {
   }
   
   .hs-button:hover {
-    background-color: rgb(88, 38, 193);
+    background-color: var(--sd-color-secondary-dark);
   }
   
   .hs_error_rollup {
@@ -328,7 +358,7 @@ body, .diagram-font {
   }
   
   .beta {
-    background: #7a41ce;
+    background: var(--sd-color-primary);
     color: white;
     border-radius: 4px;
     padding: 4px 6px;
@@ -352,7 +382,7 @@ body, .diagram-font {
   }
   
   table.custom-table thead tr{
-    background-color: #3170f4;
+    background-color: var(--sd-color-primary);
     color: #ffffff;
     text-align: center;
   }
@@ -362,7 +392,7 @@ body, .diagram-font {
   }
   
   table.custom-table tbody tr:nth-of-type(even) {
-    background-color: #f6f8fA;
+    background-color: var(--sd-color-secondary);
   }
 
 
@@ -392,7 +422,7 @@ body, .diagram-font {
 
 
 blockquote {
-  background-color: #f4f9ff; /* light blue background */
+  background-color: var(--sd-color-secondary);
   border-left: none;
   padding: 1em;
   font-family: sans-serif;
@@ -405,7 +435,7 @@ blockquote {
 blockquote::before {
   content: 'ℹ️ Info:';
   display: block;
-  background-color: #b9dafd; /* light blue bar */
+  background-color: var(--sd-color-secondary); /* light blue bar */
   color: #111;
   font-weight: bold;
   padding: 0.25em;


### PR DESCRIPTION
Hi folks, this PR brings the same CSS we are using in VCP CLI to this repo.

https://chanzuckerberg.github.io/vcp-cli/

This will make cz-benchmarks colors match the current platform and CLI look.

Not sure if this is in scope for NeurIPS, but it should be a simple change.