### PR TITLE
refactor: improve cross-species options

### DIFF
--- a/src/czbenchmarks/tasks/single_cell/cross_species_integration.py
+++ b/src/czbenchmarks/tasks/single_cell/cross_species_integration.py
@@ -22,21 +22,21 @@ class CrossSpeciesIntegrationTaskInput(TaskInput):
     labels: Annotated[
         List[ListLike],
         Field(
-            description="List of ground truth labels for each species dataset (e.g., cell types)."
+            description="Ground truth labels for each species dataset (e.g., cell types)."
         ),
     ]
-    organism_list: Annotated[
+    organisms: Annotated[
         List[Organism],
         Field(
-            description="List of organisms corresponding to each dataset for cross-species evaluation."
+            description="Organism for each species dataset."
         ),
     ]
 
-    @field_validator("organism_list")
+    @field_validator("organisms")
     @classmethod
-    def _validate_organism_list(cls, v: List[Organism]) -> List[Organism]:
+    def _validate_organisms(cls, v: List[Organism]) -> List[Organism]:
         if not isinstance(v, list):
-            raise ValueError("organism_list must be a list of organisms.")
+            raise ValueError("organisms must be a list of organisms.")
         return v
 
 
@@ -56,7 +56,7 @@ class CrossSpeciesIntegrationTask(Task):
     datasets from different species.
     """
 
-    display_name = "Cross-species Integration"
+    display_name = "Cross Species Integration"
     description = (
         "Evaluate cross-species integration quality using various integration metrics."
     )
@@ -93,10 +93,10 @@ class CrossSpeciesIntegrationTask(Task):
         cell_representation = np.vstack(cell_representation)
 
         # FIXME BYODATASET move this into validation
-        if len(set(task_input.organism_list)) < 2:
+        if len(set(task_input.organisms)) < 2:
             raise AssertionError(
                 "At least two organisms are required for cross-species integration "
-                f"but got {len(set(task_input.organism_list))} : {set(task_input.organism_list)}"
+                f"but got {len(set(task_input.organisms))} : {set(task_input.organisms)}"
             )
 
         species = np.concatenate(
@@ -105,7 +105,7 @@ class CrossSpeciesIntegrationTask(Task):
                     str(organism),
                 ]
                 * len(label)
-                for organism, label in zip(task_input.organism_list, task_input.labels)
+                for organism, label in zip(task_input.organisms, task_input.labels)
             ]
         )
         labels = np.concatenate(task_input.labels)

--- a/src/czbenchmarks/tasks/single_cell/cross_species_label_prediction.py
+++ b/src/czbenchmarks/tasks/single_cell/cross_species_label_prediction.py
@@ -38,13 +38,13 @@ class CrossSpeciesLabelPredictionTaskInput(TaskInput):
     labels: Annotated[
         List[ListLike],
         Field(
-            description="List of ground truth labels for each species dataset (e.g., cell types)."
+            description="Ground truth labels for each species dataset (e.g., cell types)."
         ),
     ]
     organisms: Annotated[
         List[Organism],
         Field(
-            description="List of organisms corresponding to each dataset for cross-species evaluation."
+            description="Organism for each species dataset."
         ),
     ]
     sample_ids: Annotated[
@@ -105,7 +105,7 @@ class CrossSpeciesLabelPredictionTask(Task):
     before running classification.
     """
 
-    display_name = "cross-species label prediction"
+    display_name = "Cross Species Label Prediction"
     description = "Evaluate cross-species label prediction performance using multiple classifiers."
 
     input_model = CrossSpeciesLabelPredictionTaskInput

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -171,9 +171,9 @@ def test_cross_species_task(embedding_matrix, obs):
     embedding_list = [embedding_matrix, embedding_matrix]
     labels = obs["cell_type"]
     labels_list = [labels, labels]
-    organism_list = [Organism.HUMAN, Organism.MOUSE]
+    organisms = [Organism.HUMAN, Organism.MOUSE]
     task_input = CrossSpeciesIntegrationTaskInput(
-        labels=labels_list, organism_list=organism_list
+        labels=labels_list, organisms=organisms
     )
 
     try:

--- a/tests/test_dataset_task_e2e_regression.py
+++ b/tests/test_dataset_task_e2e_regression.py
@@ -389,7 +389,7 @@ def test_cross_species_integration_task_regression(
     # Run cross-species integration task with fixture embeddings for all 3 species
     cross_species_task_input = CrossSpeciesIntegrationTaskInput(
         labels=[human_dataset.labels, mouse_dataset.labels, rhesus_dataset.labels],
-        organism_list=[
+        organisms=[
             human_dataset.organism,
             mouse_dataset.organism,
             rhesus_dataset.organism,


### PR DESCRIPTION
- Rename cz-benchmarks CrossSpeciesIntegrationTask.organism_list to organisms (for consistency with CrossSpeciesLabelPrediction)
- Reword cz-benchmarks CrossSpecies{Integration,LabelPrediction}Task option descriptions
- Rename task keys:  cross-species_integration --> cross_species_integration  and cross-species_label_prediction  → cross_species_label_prediction (note: change dash to underscore)