### PR TITLE
fix: add random_seed parameter to sequential_alignment metric

### DIFF
--- a/src/czbenchmarks/tasks/sequential.py
+++ b/src/czbenchmarks/tasks/sequential.py
@@ -146,6 +146,7 @@ class SequentialOrganizationTask(Task):
                     k=task_input.k,
                     normalize=task_input.normalize,
                     adaptive_k=task_input.adaptive_k,
+                    random_seed=self.random_seed,
                 ),
                 params={},
             )


### PR DESCRIPTION
[VC-4700](https://czi.atlassian.net/browse/VC-4700)
* Added random_seed parameter to sequential_alignment metric
* Propagated random_seed to _compute_random_baseline
* Passed random_seed from SequentialOrganizationTask to the metric
* Added unit test for random seed propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VC-4700]: https://czi.atlassian.net/browse/VC-4700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ