### PR TITLE
fix: Resolve custom config with OmegaConf

### DIFF
--- a/src/czbenchmarks/utils.py
+++ b/src/czbenchmarks/utils.py
@@ -185,5 +185,8 @@ def load_custom_config(
             cfg[config_name][item_name], class_update_kwargs
         )
 
+    # Resolve any OmegaConf resolvers in the custom config (e.g., ${oc.env:HOME})
+    OmegaConf.resolve(cfg)
+
     custom_cfg = cfg[config_name][item_name]
     return custom_cfg

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -123,6 +123,20 @@ def test_import_class_from_config(tmp_path):
                 }
             },
         ),
+        # YAML-only example for OmegaConf resolver
+        (
+            "yaml_resolved_dataset",
+            None,
+            {
+                "datasets": {
+                    "yaml_resolved_dataset": {
+                        "_target_": "czbenchmarks.datasets.dummy.DummyDataset",
+                        "path": r"""${oc.env:HOME}/yaml_resolved_dataset.h5ad""",
+                        "organism": Organism.HUMAN,
+                    }
+                }
+            },
+        ),
     ],
 )
 def test_load_custom_config(
@@ -133,6 +147,7 @@ def test_load_custom_config(
     # Prepare YAML file from parameterized content
     custom_yaml_path = None
     if custom_yaml_content:
+        # custom_yaml_content = OmegaConf.create(custom_yaml_content)
         custom_yaml_path = tmp_path / "custom_config.yaml"
         OmegaConf.save(config=custom_yaml_content, f=custom_yaml_path)
         custom_yaml_path = str(custom_yaml_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -109,6 +109,16 @@ def test_import_class_from_config(tmp_path):
             },
             None,
         ),
+        # Dict-only example - test OmegaConf resolver
+        (
+            "tsv2_bladder",
+            {
+                "path": "${oc.env:HOME}/only_dict_resolver.h5ad",
+                "organism": Organism.MOUSE,  # change default organism
+                "dict_only": "yes",  # new key
+            },
+            None,
+        ),
         # YAML-only example with new dataset
         (
             "yaml_only_dataset",
@@ -131,7 +141,7 @@ def test_import_class_from_config(tmp_path):
                 "datasets": {
                     "yaml_resolved_dataset": {
                         "_target_": "czbenchmarks.datasets.dummy.DummyDataset",
-                        "path": r"""${oc.env:HOME}/yaml_resolved_dataset.h5ad""",
+                        "path": "${oc.env:HOME}/yaml_resolved_dataset.h5ad",
                         "organism": Organism.HUMAN,
                     }
                 }
@@ -147,7 +157,6 @@ def test_load_custom_config(
     # Prepare YAML file from parameterized content
     custom_yaml_path = None
     if custom_yaml_content:
-        # custom_yaml_content = OmegaConf.create(custom_yaml_content)
         custom_yaml_path = tmp_path / "custom_config.yaml"
         OmegaConf.save(config=custom_yaml_content, f=custom_yaml_path)
         custom_yaml_path = str(custom_yaml_path)
@@ -161,6 +170,10 @@ def test_load_custom_config(
 
     # All dict-provided keys should be present and match
     if custom_dataset_config:
+        # Ensure the input dict content is resolved for comparisons
+        custom_dataset_config = OmegaConf.create(custom_dataset_config)
+        OmegaConf.resolve(custom_dataset_config)
+
         for key, value in custom_dataset_config.items():
             if key == "organism":
                 assert str(custom_cfg[key]) == str(value)
@@ -169,6 +182,10 @@ def test_load_custom_config(
 
     # YAML-provided keys for this item should be present; when overlapping, dict wins
     if custom_yaml_content:
+        # Ensure the input YAML content is resolved for comparisons
+        custom_yaml_content = OmegaConf.create(custom_yaml_content)
+        OmegaConf.resolve(custom_yaml_content)
+
         yaml_items = custom_yaml_content.get("datasets", {}).get(dataset_name, {})
         if yaml_items:
             for key, yaml_value in yaml_items.items():


### PR DESCRIPTION
This PR is a fix to ensure that any OmegaConf syntax sugar, e.g. `${oc.env:HOME}`, is properly resolved. in the custom config function. The test has been updated to ensure this is caught in the future.