### PR TITLE
Add lognorm labelprediction baseline

### DIFF
--- a/examples/end-to-end-tutorial.py
+++ b/examples/end-to-end-tutorial.py
@@ -52,6 +52,8 @@ import seaborn as sns
 from tabulate import tabulate
 import os
 import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
 
 # Set up basic logging to see the library's output
 logging.basicConfig(level=logging.INFO, stream=sys.stdout)
@@ -81,7 +83,7 @@ local_model_dir = "/tmp/czbenchmarks_scvi_model"
 
 if not os.path.exists(local_model_dir):
     os.makedirs(local_model_dir, exist_ok=True)
-    s3 = boto3.resource("s3")
+    s3 = boto3.resource("s3", config=Config(signature_version=UNSIGNED))
     bucket_name = "cz-benchmarks-data"
     prefix = "models/v1/scvi_2023_12_15/homo_sapiens/"
     bucket = s3.Bucket(bucket_name)

--- a/src/czbenchmarks/tasks/label_prediction.py
+++ b/src/czbenchmarks/tasks/label_prediction.py
@@ -1,7 +1,8 @@
 import logging
-from typing import Any, Dict, List, Annotated
+from typing import Any, Dict, List, Annotated, Literal
 from pydantic import Field, field_validator
 
+import numpy as np
 import pandas as pd
 import scipy.sparse
 from sklearn.ensemble import RandomForestClassifier
@@ -79,12 +80,32 @@ class MetadataLabelPredictionOutput(TaskOutput):
 
 
 class LabelPredictionBaselineInput(BaselineInput):
-    """
-    This baseline uses the raw gene expression matrix as features.
-    It has no configurable parameters.
+    """Baseline preprocessing options for label prediction task.
+
+    The default (preprocessing="lognorm") applies standard scRNA-seq preprocessing:
+    library size normalization to target_sum followed by log1p transformation.
+
+    The "raw" option returns counts as-is (relying on the classifier's built-in
+    StandardScaler). This is provided for comparison purposes but is not
+    recommended as a baseline.
     """
 
-    pass
+    preprocessing: Literal["lognorm", "raw"] = Field(
+        "lognorm",
+        description="Preprocessing mode: 'lognorm' (recommended) applies library size "
+        "normalization and log1p; 'raw' returns counts as-is.",
+    )
+    target_sum: float = Field(
+        1e4,
+        description="Target sum for library size normalization (only used when preprocessing='lognorm').",
+    )
+
+    @field_validator("target_sum")
+    @classmethod
+    def _validate_target_sum(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError("target_sum must be positive.")
+        return v
 
 
 class MetadataLabelPredictionTask(Task):
@@ -346,13 +367,31 @@ class MetadataLabelPredictionTask(Task):
         expression_data: CellRepresentation,
         baseline_input: LabelPredictionBaselineInput = None,
     ) -> CellRepresentation:
-        """Set a baseline cell representation using raw gene expression.
+        """Compute baseline cell representation.
 
-        This baseline uses the raw gene expression matrix directly as features.
+        By default, applies standard scRNA-seq preprocessing: library size
+        normalization and log1p transformation.
+
+        Args:
+            expression_data: Raw count matrix (cells x genes)
+            baseline_input: LabelPredictionBaselineInput
+
+        Returns:
+            Preprocessed expression matrix suitable for classification
         """
         if baseline_input is None:
             baseline_input = LabelPredictionBaselineInput()
 
         if scipy.sparse.issparse(expression_data):
             expression_data = expression_data.toarray()
+
+        if baseline_input.preprocessing == "raw":
+            return expression_data
+
+        #lognorm preprocessing
+        row_sums = expression_data.sum(axis=1, keepdims=True)
+        row_sums = np.where(row_sums == 0, 1, row_sums)  # Avoid division by zero
+        expression_data = expression_data / row_sums * baseline_input.target_sum
+        expression_data = np.log1p(expression_data)
+
         return expression_data


### PR DESCRIPTION
Currently the baseline for the metadata label prediction task uses the raw counts, fed to a StandardScaler and LogisticRegression model. This gives significantly worse performance than using the standard conditioning for scRNA data, which is library normalization (usually to a count of 1000) and log1p transformation. 

This PR adds a standard simple implementation of the lognorm preprocessing as the default baseline for the metadata prediction task.

To test that this is working as expected and that it indeed has an impact on the results, I ran a modified version of the `end-to-end-tutorial` on all 26 datasets of tsv2, comparing the performance of scVI vectors to raw counts vs lognormed counts using the logistic regression model only from the pipeline and measuring the f1_macro. As expected, lognorm significantly improved performance and matched scVI.

The code that I used to run these experiments is available [multidataset_tutorial.py](https://github.com/user-attachments/files/24455838/multidataset_tutorial.py) I don't mind adding it to the PR if maintainers think it's a worthwhile contribution.

As such, I think that the package should really use the properly conditioned baseline, to identify more clearly the advantages of the new models.

<img width="1732" height="1076" alt="image" src="https://github.com/user-attachments/assets/25bb3374-295c-4beb-8a20-6a1f24a887a5" />
