### PR TITLE
Validate non-null labels in aggregate_cells_to_samples

### DIFF
--- a/src/czbenchmarks/tasks/utils.py
+++ b/src/czbenchmarks/tasks/utils.py
@@ -415,6 +415,13 @@ def aggregate_cells_to_samples(
             f"labels={len(labels)}, sample_ids={len(sample_ids)}"
         )
 
+    null_mask = labels.isna()
+    if null_mask.any():
+        null_count = null_mask.sum()
+        raise ValueError(
+            f"labels contain {null_count} null value(s); all labels must be non-null"
+        )
+
     # Create DataFrame with embeddings and metadata
     emb_df = pd.DataFrame(embeddings)
     emb_df["sample_id"] = sample_ids

--- a/tests/tasks/test_utils.py
+++ b/tests/tasks/test_utils.py
@@ -102,6 +102,27 @@ def test_aggregate_cells_to_samples_types():
     pd.testing.assert_series_equal(sample_ids_out, sample_ids_out2)
 
 
+def test_aggregate_cells_to_samples_null_labels():
+    """Test that null labels raise a ValueError."""
+    embeddings = np.random.randn(5, 3)
+    sample_ids = ["s1"] * 5
+
+    # None values in a list
+    labels_with_none = ["A", "B", None, "A", "B"]
+    with pytest.raises(ValueError, match="null value"):
+        aggregate_cells_to_samples(embeddings, labels_with_none, sample_ids)
+
+    # np.nan in a numpy array
+    labels_with_nan = np.array(["A", "B", np.nan, "A", "B"], dtype=object)
+    with pytest.raises(ValueError, match="null value"):
+        aggregate_cells_to_samples(embeddings, labels_with_nan, sample_ids)
+
+    # pd.Series with NaN
+    labels_series_nan = pd.Series(["A", None, "B", "A", "B"])
+    with pytest.raises(ValueError, match="null value"):
+        aggregate_cells_to_samples(embeddings, labels_series_nan, sample_ids)
+
+
 def test_aggregate_cells_to_samples_label_consistency():
     """Test that each sample gets a consistent label."""
     # Create data where each sample has mixed labels initially


### PR DESCRIPTION
## Summary

- Add null-label check in `aggregate_cells_to_samples()` after existing length validation — raises `ValueError` with count of null values found
- Add test covering three input variants: list with `None`, numpy array with `np.nan`, and `pd.Series` with `None`

Closes #435

## Test plan

- [ ] `aggregate_cells_to_samples()` raises `ValueError` when labels contain null values
- [ ] Existing tests still pass (`tests/tasks/test_utils.py`)
- [ ] Run full test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)